### PR TITLE
Feature/#1 하단 네비게이션 바 및 페이지 템플릿 컴포넌트 컴포넌트 생성 및 레이아웃 정의

### DIFF
--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -1,0 +1,27 @@
+import * as S from "../../styles/common/BottomNavBar.style";
+
+type NavItemType = "홈" | "내 여행" | "스크랩" | "MY";
+
+interface Props {
+  location: NavItemType;
+}
+
+function BottomNavBar({ location = "홈" }: Props) {
+  const navItems: NavItemType[] = ["홈", "내 여행", "스크랩", "MY"];
+  return (
+    <S.Nav>
+      <S.NavList>
+        {navItems.map((item: string) => (
+          <S.ListItem className={`${location === item && "active"}`}>
+            <a>
+              (아이콘)
+              <span>{item}</span>
+            </a>
+          </S.ListItem>
+        ))}
+      </S.NavList>
+    </S.Nav>
+  );
+}
+
+export default BottomNavBar;

--- a/src/components/common/PageTemplate.tsx
+++ b/src/components/common/PageTemplate.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+import BottomNavBar from "./BottomNavBar";
+// import Header from "../components/common/Header";
+import * as S from "../../styles/common/PageTemplate.style";
+
+interface Props {
+  children: ReactNode;
+  header?: boolean;
+  nav?: boolean;
+}
+
+function PageTemplate({ children, header = true, nav = true }: Props) {
+  return (
+    <S.Container>
+      {/* {header && <Header />} */}
+      {children}
+      {nav && <BottomNavBar location="내 여행" />}
+    </S.Container>
+  );
+}
+
+export default PageTemplate;

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import PageTemplate from "../components/common/PageTemplate";
+
+function SchedulePage() {
+  return (
+    <PageTemplate nav={true} header={false}>
+      여행 일정 페이지
+    </PageTemplate>
+  );
+}
+
+export default SchedulePage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,16 @@
 import { createBrowserRouter } from "react-router-dom";
 import App from "./pages/App";
+import SchedulePage from "./pages/SchedulePage";
 
 const router = createBrowserRouter([
-    {
-        path: "/",
-        element: <App />,
-    },
+  {
+    path: "/",
+    element: <App />,
+  },
+  {
+    path: "/schedule",
+    element: <SchedulePage />,
+  },
 ]);
 
 export default router;

--- a/src/styles/common/BottomNavBar.style.ts
+++ b/src/styles/common/BottomNavBar.style.ts
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+
+export const Nav = styled.nav`
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+`;
+export const NavList = styled.ul`
+  margin: auto;
+  margin-bottom: 19px;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+`;
+export const ListItem = styled.li`
+  a {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  /* width: 100%; */
+`;

--- a/src/styles/common/PageTemplate.style.ts
+++ b/src/styles/common/PageTemplate.style.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  margin: auto;
+  max-width: 500px;
+  width: 100%;
+  height: 100vh;
+  position: relative;
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,13 +1,23 @@
 const theme = {
     white: "#FFFFF",
-    lightGray: "#F6F6F6",
-    gray: "#D3D3D3",
-    normalGray: "#ADADAD",
-    darkGray: "#727272",
     black: "#121212",
-    primary: "#5276FA",
-    primaryBlack: "#3C3C43",
-    alertRed: "#FF6060",
+    red: "#FF6060",
+
+    main: "#5276FA",
+    blue01: "#4969E0",
+    blue02: "#849FFF",
+    blue03: "#ACBAF3",
+    blue04: "#D4DDFF",
+    blue05: "#F3F6FF",
+
+    gray: "#424242",
+    gray01: "#727272",
+    gray02: "#ADADAD",
+    gray03: "#D3D3D3",
+    gray04: "#EBEBEB",
+    gray05: "#F3F4F6",
+    gray06: "#F6F6F6",
+    gray07: "#FDFDFD",
 };
 
 export default theme;


### PR DESCRIPTION
### 작업한 내용
- 하단 네비게이션 바 레이아웃
- 페이지 템플릿 레이아웃

### 중점적으로 봐 주었으면 하는 부분
- 스타일링은 추가 작업 할 예정이고, styled-components 사용하는 코드(S dot 기법)에 이상이 없는지 등 코드 스타일이 어떤지 봐주셨으면 합니다.
- `pages/` 폴더 아래 생성하는 페이지 컴포넌트에서 공통적으로 사용할 수 있는 페이지 템플릿 컴포넌트를 생성했는데, 이런 느낌으로 사용할만한지 피드백 부탁드려요!

<img width="300" alt="image" src="https://github.com/F-orever/gabozago_FE/assets/102221305/41eac371-44d6-49b0-9038-c37683b476d8">
