### PR TITLE
Feature/#1 Schedule 페이지 이름 변경 및 스크롤 영역 수정

### DIFF
--- a/src/components/common/PageTemplate.tsx
+++ b/src/components/common/PageTemplate.tsx
@@ -13,7 +13,7 @@ function PageTemplate({ children, header = true, nav = true }: Props) {
   return (
     <S.Container>
       {/* {header && <Header />} */}
-      {children}
+      <S.Content>{children}</S.Content>
       {nav && <BottomNavBar location="내 여행" />}
     </S.Container>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,11 +8,11 @@ import router from "./router";
 
 //This is develop branch
 ReactDOM.createRoot(document.getElementById("root")!).render(
-    <RecoilRoot>
-        <GlobalFont />
-        <GlobalStyle />
-        <ThemeProvider theme={theme}>
-            <RouterProvider router={router} />
-        </ThemeProvider>
-    </RecoilRoot>
+  <RecoilRoot>
+    <ThemeProvider theme={theme}>
+      <GlobalFont />
+      <GlobalStyle />
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  </RecoilRoot>
 );

--- a/src/pages/MyTripPage.tsx
+++ b/src/pages/MyTripPage.tsx
@@ -1,0 +1,11 @@
+import PageTemplate from "../components/common/PageTemplate";
+
+function SchedulePage() {
+  return (
+    <PageTemplate nav={true} header={false}>
+      내 여행 페이지
+    </PageTemplate>
+  );
+}
+
+export default SchedulePage;

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -3,7 +3,7 @@ import useSearchInput from "../hooks/useSearchInput";
 import useModal from "../hooks/useModal";
 import usePopup from "../hooks/usePopup";
 
-function SchedulePage() {
+function TestPage() {
   const [, SearchInput] = useSearchInput({});
   const { Modal, modalOpen } = useModal({
     title: "제목입력",
@@ -15,9 +15,7 @@ function SchedulePage() {
       <Modal>
         <div>TEST</div>
       </Modal>
-      <Popup title="신고하기" padding="30px 40px">
-        신고가 접수되었습니다.
-      </Popup>
+      <Popup padding="30px 40px">신고가 접수되었습니다.</Popup>
       <SearchInput />
       여행 일정 페이지
       <button onClick={modalOpen}>모달 open</button>
@@ -26,4 +24,4 @@ function SchedulePage() {
   );
 }
 
-export default SchedulePage;
+export default TestPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from "react-router-dom";
 import App from "./pages/App";
-import SchedulePage from "./pages/SchedulePage";
+import MyTripPage from "./pages/MyTripPage";
+import TestPage from "./pages/TestPage";
 
 const router = createBrowserRouter([
   {
@@ -8,8 +9,12 @@ const router = createBrowserRouter([
     element: <App />,
   },
   {
-    path: "/schedule",
-    element: <SchedulePage />,
+    path: "/mytrip",
+    element: <MyTripPage />,
+  },
+  {
+    path: "/test",
+    element: <TestPage />,
   },
 ]);
 

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -28,6 +28,7 @@ const GlobalStyle = createGlobalStyle`
 	}
 	body {
 		line-height: 1;
+		background-color: ${({ theme }) => theme.gray04};
 	}
 	ol, ul {
 		list-style: none;

--- a/src/styles/common/PageTemplate.style.ts
+++ b/src/styles/common/PageTemplate.style.ts
@@ -1,11 +1,15 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
   margin: auto;
   max-width: 500px;
   width: 100%;
   height: 100vh;
-  position: fixed;
   background-color: ${({ theme }) => theme.white};
 `;
 

--- a/src/styles/common/PageTemplate.style.ts
+++ b/src/styles/common/PageTemplate.style.ts
@@ -5,5 +5,13 @@ export const Container = styled.div`
   max-width: 500px;
   width: 100%;
   height: 100vh;
-  position: relative;
+  position: fixed;
+  background-color: ${({ theme }) => theme.white};
+`;
+
+export const Content = styled.div`
+  width: 100%;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 32px 20px;
 `;


### PR DESCRIPTION
### 작업한 내용
- body 백그라운드를 회색으로 변경해 메인 영역과 구분되도록 만들었습니다. Global Style에서 theme를 사용하기 위해 ThemeProvider의 위치를 옮겼습니다.
- 콘텐츠가 길어졌을 때 스크롤이 되고 하단바가 fix되어 움직이지 않도록 만들었습니다.
- Schedule 페이지 컴포넌트 이름을 봤을 때 직관적으로 어디인지 알기 어려운 것 같아서 MyTrip으로 변경했습니다.
- 이전 Schedule 페이지에 있던 UI 테스트는 TestPage를 만들어 옮겼습니다.

![image](https://github.com/F-orever/gabozago_FE/assets/102221305/f1a7e2df-b166-4ef8-a9fe-71ca74c8b2e9)
