### PR TITLE
Feature/#89 장소 페이지 + 단일 장소 여행일정에 추가 페이지

### DIFF
--- a/src/components/common/PageHeader/style.ts
+++ b/src/components/common/PageHeader/style.ts
@@ -2,7 +2,7 @@ import styled from "styled-components"
 
 export const Header = styled.header`
     width:100%;
-    padding:6px 20px;
+    padding:15px 20px;
     position:relative;
 
     display:flex;

--- a/src/components/common/Typography/Body/index.tsx
+++ b/src/components/common/Typography/Body/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 function Headline({ children, size, noOfLine, maxWidth, color }: Props) {
     return (
-        <S.Body size={size} noOfLine={noOfLine} maxWidth={maxWidth}>
+        <S.Body size={size} noOfLine={noOfLine} maxWidth={maxWidth} color={color}>
             {children}
         </S.Body>
     );

--- a/src/components/journal/GoogleMap/index.tsx
+++ b/src/components/journal/GoogleMap/index.tsx
@@ -2,6 +2,8 @@ import { useJsApiLoader, GoogleMap, Marker } from "@react-google-maps/api";
 import { useCallback, useState } from "react";
 
 interface Props {
+    width?: string;
+    height?: string;
     markers?: {
         lat: number,
         lng: number,
@@ -12,7 +14,7 @@ interface Props {
     }
 }
 
-function PlaceGoogleMap({markers, center} : Props) {
+function PlaceGoogleMap({width, height, markers, center} : Props) {
     const { isLoaded } = useJsApiLoader({
         id: 'google-map-script',
         googleMapsApiKey: import.meta.env.VITE_GOOGLEMAP_KEY,
@@ -27,35 +29,37 @@ function PlaceGoogleMap({markers, center} : Props) {
     }, [])
     const onUnmount = useCallback(function callback(map: any) {
         setMap(null)
-      }, [])
+    }, [])
 
-      return(
-        <>
-            {
-                isLoaded && <GoogleMap
-                    mapContainerStyle={{
-                        width: '100%',
-                        height: '100px',
-                        borderRadius: '6px',
-                    }}
-                    center={center}
-                    onLoad={onLoad}
-                    onUnmount={onUnmount}
-                    options={{
-                        fullscreenControl:false,
-                        keyboardShortcuts:false,
-                        mapTypeControl:false,
-                    }}
-                >
-                    {
-                        markers?.map((marker) => 
-                            <Marker position={marker} />
-                        )
-                    }
-                </GoogleMap>
-            }
-        </>
-      )
+    return(
+    <>
+        {
+            isLoaded && <GoogleMap
+                mapContainerStyle={{
+                    width: `${width ? width : "100%"}`,
+                    height: `${height ? height : "100px"}`,
+                    borderRadius: '6px',
+                }}
+                center={center}
+                onLoad={onLoad}
+                onUnmount={onUnmount}
+                options={{
+                    fullscreenControl:false,
+                    keyboardShortcuts:false,
+                    mapTypeControl:false,
+                    zoomControl:false,
+                    streetViewControl:false,
+                }}
+            >
+                {
+                    markers?.map((marker) => 
+                        <Marker position={marker} />
+                    )
+                }
+            </GoogleMap>
+        }
+    </>
+    )
 }
 
 export default PlaceGoogleMap;

--- a/src/components/journal/PlaceOperateTime/index.tsx
+++ b/src/components/journal/PlaceOperateTime/index.tsx
@@ -16,7 +16,7 @@ function PlaceOperateTime({opening_hours}: Props) {
     const date = new Date();
 
     useEffect(() => {
-        setData(opening_hours.split("\n").map((item) => item.split(": ")))
+            setData(opening_hours.split("\n").map((item) => item.split(": ")))
     }, []);
 
     useEffect(() => {

--- a/src/components/journal/PlaceOperateTime/index.tsx
+++ b/src/components/journal/PlaceOperateTime/index.tsx
@@ -5,93 +5,36 @@ import ChevronBottomIcon from "../../../assets/icons/chevron_bottom.svg?react";
 
 import * as S from "./style";
 
-const operateTime = [
-    {
-        day: "SUN",
-        startTime: -1,
-        endTime: -1
-    },
-    {
-        day: "MON",
-        startTime: 9,
-        endTime: 18
-    },
-    {
-        day: "THU",
-        startTime: 9,
-        endTime: 18
-    },
-    {
-        day: "WED",
-        startTime: 9,
-        endTime: 18
-    },
-    {
-        day: "THUR",
-        startTime: 9,
-        endTime: 18
-    },
-    {
-        day: "FRI",
-        startTime: 9,
-        endTime: 18
-    },
-    {
-        day: "SAT",
-        startTime: 9,
-        endTime: 18
-    }
-]
-
-function converDate(date: string) {
-    switch(date) {
-        case "MON" :
-            return "월요일";
-            break;
-        case "THU" :
-            return "화요일";
-            break;
-        case "WED" :
-            return "수요일";
-            break;
-        case "THUR" :
-            return "목요일";
-            break;
-        case "FRI" :
-            return "금요일";
-            break;
-        case "SAT" :
-            return "토요일";
-            break;
-        case "SUN" :
-            return "일요일";
-            break;
-    }
+interface Props {
+    opening_hours: string,
 }
 
-function convertTime(time: number) {
-    if(time > 12) {
-        return `오후 ${(time - 12)}:00`;
-    }
-    else { 
-        return `오전 ${time}:00`;
-    }
-
-}
-
-function PlaceOperateTime() {
+function PlaceOperateTime({opening_hours}: Props) {
     const [isOpen, setIsOpen] = useState(false);
     const [isOperate, setIsOperate] = useState(false);
+    const [data, setData] = useState<string[][]>();
+    const date = new Date();
 
     useEffect(() => {
-        const current = new Date();
-        const currentTime = current.getHours() * 60 + current.getMinutes();
-        if(operateTime[current.getDay()].startTime * 60 < currentTime && operateTime[current.getDay()].endTime  * 60 < currentTime) {
-            setIsOperate(true);
-        } else {
-            setIsOperate(false);
+        setData(opening_hours.split("\n").map((item) => item.split(": ")))
+    }, []);
+
+    useEffect(() => {
+        if(data) {
+            let [startType , startTime,  ] = data[`${date.getDay() === 0 ? 6 : date.getDay() - 1}`][1].split("~")[0].split(" ");
+            let [ , endType, endTime] = data[`${date.getDay() === 0 ? 6 : date.getDay() - 1}`][1].split("~")[1].split(" ");
+            console.log(date.getHours());
+            console.log(startType, startTime);
+            console.log(endType, endTime);
+
+            let calcStartTime = startType === "오전" ? Number(startTime) : Number(startTime) + 12;
+            let calcEndTime = endType === "오전" ? Number(endTime) : Number(endTime) + 12;
+
+            if(date.getHours() > calcStartTime && date.getHours() < calcEndTime) {
+                setIsOperate(true);
+            }
         }
-    }, [])
+    }, [data])
 
     return(
         <S.Container>
@@ -102,7 +45,7 @@ function PlaceOperateTime() {
                     <span className="red">영업종료</span>
                 }
                 <span>∙</span>
-                <span>{convertTime(operateTime[1].endTime)} 영업 종료</span>
+                <span>{ data && data[`${date.getDay() === 0 ? 6 : date.getDay() - 1}`][1].split("~")[1] } 영업 종료</span>
                 {
                     isOpen ?
                     <ChevronTopIcon onClick={() => {setIsOpen(prev => !prev)}} />
@@ -113,17 +56,10 @@ function PlaceOperateTime() {
             {isOpen &&
             <S.OperateTimeList>
                 {
-                    operateTime.map((item) => 
+                    data && data.map((item) => 
                         <S.OperateTimeItem>
-                            <span>
-                                {converDate(item.day)}
-                            </span>
-                            {item.startTime !== -1 ?
-                                <span>{convertTime(item.startTime)} ~ {convertTime(item.endTime)}</span>
-                            :
-                                <span className="red">휴무일</span>
-                            }
-
+                            <span>{item[0]}</span>
+                            <span>{item[1]}</span>
                         </S.OperateTimeItem>
                     )
                 }

--- a/src/components/mytrip/CalendarContainer/index.tsx
+++ b/src/components/mytrip/CalendarContainer/index.tsx
@@ -6,11 +6,14 @@ import { datesState } from "../../../recoil/mytrip/createData.ts";
 
 import Button from "../../common/Button/index.tsx";
 import Calendar from "../Calendar/index.tsx";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { createTravelState } from "../../../recoil/mytrip/createTravelState.ts";
 
+//[SugarSyrup] @TODO: CreateType에 따라 버튼의 동작 방식 변경
 function CalendarContainer() {
     const [dateClickFlag, setDateClickFlag] = useState<boolean>(true);
     const [dateDiff, setDateDiff] = useState<number>(-1);
+    const createType = useRecoilValue(createTravelState);
 
     const [dates, setDates] = useRecoilState(datesState);
 

--- a/src/components/mytrip/LocationAddItem/index.tsx
+++ b/src/components/mytrip/LocationAddItem/index.tsx
@@ -1,32 +1,25 @@
-import * as S from "./style";
+import React, { Dispatch, useState } from "react";
 
 import LogoIcon from "../../../assets/icons/logo_small.svg?react";
 import CalendarIcon from "../../../assets/icons/calendar.svg?react";
 import LocationIcon from "../../../assets/icons/location.svg?react";
+import { TMyTravelItem } from "../../../pages/mytrip/PlaceAddPage";
+
 import Typography from "../../common/Typography";
-import { useState } from "react";
+
+import * as S from "./style";
 
 interface Props {
-    "id": number,
-    "name": string,
-    "departureDate": string,
-    "arrivalDate": string,
-    "location": string[],
-    "days": {
-        "day": number,
-        "date": string,
-        "dayOfWeek": string,
-    }[],
-    "thumbnailURL": string,
+    currentSelectedItemId: number;
+    setCurrentSelectedItem: Dispatch<React.SetStateAction<{id:number, day?:number}>>;
 }
 
-function LocationAddItem({id, name, departureDate, arrivalDate, location, days, thumbnailURL}: Props) {
-    const [isItemClick, setIsItemClick] = useState<boolean>(false);
+function LocationAddItem({id, name, departureDate, arrivalDate, location, days, thumbnailURL, currentSelectedItemId ,setCurrentSelectedItem}: TMyTravelItem & Props) {
     const [clickedDay, setClickedDay] = useState<number>(-1);
 
     return(
         <S.Container>
-            <S.InfoContainer onClick={() => {setIsItemClick(prev => !prev)}}>
+            <S.InfoContainer onClick={() => {setCurrentSelectedItem({id: id})}}>
                 <S.MyTravelItemThumbnailWrapper>
                     {
                         thumbnailURL !== "" ?
@@ -48,11 +41,14 @@ function LocationAddItem({id, name, departureDate, arrivalDate, location, days, 
                 </S.MyTravelItemTextContainer>
             </S.InfoContainer>
             {
-                isItemClick &&
+                currentSelectedItemId === id &&
                 <S.DayList>
                     {
                         days.map((day, index) => 
-                            <S.DayItem isClicked={index === clickedDay} onClick={() => {setClickedDay(index)}}>
+                            <S.DayItem isClicked={index === clickedDay} onClick={() => {
+                                    setClickedDay(index);
+                                    setCurrentSelectedItem({id: id, day: day.day});
+                                }}>
                                 <Typography.Label size="lg" color="inherit">Day {day.day}</Typography.Label>
                                 <Typography.Label size="sm">{day.date}({day.dayOfWeek})</Typography.Label>
                             </S.DayItem>

--- a/src/components/mytrip/LocationAddItem/index.tsx
+++ b/src/components/mytrip/LocationAddItem/index.tsx
@@ -19,7 +19,9 @@ function LocationAddItem({id, name, departureDate, arrivalDate, location, days, 
 
     return(
         <S.Container>
-            <S.InfoContainer onClick={() => {setCurrentSelectedItem({id: id})}}>
+            <S.InfoContainer onClick={() => {
+                setCurrentSelectedItem({id: id})
+            }}>
                 <S.MyTravelItemThumbnailWrapper>
                     {
                         thumbnailURL !== "" ?

--- a/src/components/mytrip/LocationAddItem/index.tsx
+++ b/src/components/mytrip/LocationAddItem/index.tsx
@@ -1,0 +1,67 @@
+import * as S from "./style";
+
+import LogoIcon from "../../../assets/icons/logo_small.svg?react";
+import CalendarIcon from "../../../assets/icons/calendar.svg?react";
+import LocationIcon from "../../../assets/icons/location.svg?react";
+import Typography from "../../common/Typography";
+import { useState } from "react";
+
+interface Props {
+    "id": number,
+    "name": string,
+    "departureDate": string,
+    "arrivalDate": string,
+    "location": string[],
+    "days": {
+        "day": number,
+        "date": string,
+        "dayOfWeek": string,
+    }[],
+    "thumbnailURL": string,
+}
+
+function LocationAddItem({id, name, departureDate, arrivalDate, location, days, thumbnailURL}: Props) {
+    const [isItemClick, setIsItemClick] = useState<boolean>(false);
+    const [clickedDay, setClickedDay] = useState<number>(-1);
+
+    return(
+        <S.Container>
+            <S.InfoContainer onClick={() => {setIsItemClick(prev => !prev)}}>
+                <S.MyTravelItemThumbnailWrapper>
+                    {
+                        thumbnailURL !== "" ?
+                        <LogoIcon />
+                        :
+                        <img src={thumbnailURL} />
+                    }
+                </S.MyTravelItemThumbnailWrapper>
+                <S.MyTravelItemTextContainer>
+                    <Typography.Title size="md">{name}</Typography.Title>
+                    <S.MyTravelItemText>
+                        <CalendarIcon />
+                        <Typography.Label size="md" color="inherit">{departureDate} ~ {arrivalDate}</Typography.Label>
+                    </S.MyTravelItemText>
+                    <S.MyTravelItemText>
+                        <LocationIcon />
+                        <Typography.Label size="md" color="inherit">{location}</Typography.Label>
+                    </S.MyTravelItemText>
+                </S.MyTravelItemTextContainer>
+            </S.InfoContainer>
+            {
+                isItemClick &&
+                <S.DayList>
+                    {
+                        days.map((day, index) => 
+                            <S.DayItem isClicked={index === clickedDay} onClick={() => {setClickedDay(index)}}>
+                                <Typography.Label size="lg" color="inherit">Day {day.day}</Typography.Label>
+                                <Typography.Label size="sm">{day.date}({day.dayOfWeek})</Typography.Label>
+                            </S.DayItem>
+                        )
+                    }
+                </S.DayList>
+            }
+        </S.Container>
+    )
+}
+
+export default LocationAddItem;

--- a/src/components/mytrip/LocationAddItem/style.ts
+++ b/src/components/mytrip/LocationAddItem/style.ts
@@ -1,0 +1,86 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+    width:100%;
+    padding:15px;
+    border-radius:10px;
+    background-color:#F6F6F6;
+
+    display:flex;
+    flex-direction:column;
+    gap:15px;
+`
+
+export const InfoContainer = styled.div`
+    display:flex;
+    justify-content:flex-start;
+    align-items:center;
+    gap:10px;
+`;
+
+export const MyTravelItemThumbnailWrapper = styled.div`
+    width:68px;
+    height:68px;
+
+    border-radius:100%;
+    background-color:#D4DDFF;
+
+    display:flex;
+    justify-content:center;
+    align-items:center;
+
+    img{
+        width:100%;
+        object-fit:contain;
+    }
+
+    svg{
+        width:24px;
+        height:24px;
+    }
+`
+
+export const MyTravelItemTextContainer = styled.div`
+    height:100%;
+    display:flex;
+    flex-direction:column;
+    justify-content:space-between;
+`
+
+export const MyTravelItemText = styled.div`
+    display:flex;
+    justify-content:flex-start;
+    align-items:center;
+    gap:5px;
+
+    color:#424242;
+
+    svg{
+        width:16px;
+        height:16px;
+
+        path{
+            fill: ${({theme}) => theme.main};
+        }
+    }
+`
+
+export const DayList = styled.div`
+    width:100%;
+    display:flex;
+    justify-content:flex-start;
+    align-items:center;
+    gap:10px;
+`
+
+export const DayItem = styled.div<{isClicked: boolean}>`
+    padding:4px 15px;
+    background-color: ${({isClicked, theme}) => isClicked ? theme.main : "white"};
+    color: ${({isClicked, theme}) => isClicked ? "white" : theme.main};
+    border: 1px solid ${({theme}) => theme.main};
+    border-radius:20px;
+
+    display:flex;
+    flex-direction:column;
+    text-align:center;
+`

--- a/src/components/video/useCourseModal/index.tsx
+++ b/src/components/video/useCourseModal/index.tsx
@@ -21,6 +21,7 @@ interface Props {
     id: number
 }
 
+// [SugarSyrup] @TODO: PM에서 대규모 수정 중
 function useCourseModal({id}: Props) {
     const [data, setCourseModalData] = useState<data>();
     const {Modal, modalOpen, modalClose} = useModal({

--- a/src/components/video/useCourseModal/index.tsx
+++ b/src/components/video/useCourseModal/index.tsx
@@ -17,7 +17,11 @@ type data = {
     }[]
 }
 
-function useCourseModal() {
+interface Props {
+    id: number
+}
+
+function useCourseModal({id}: Props) {
     const [data, setCourseModalData] = useState<data>();
     const {Modal, modalOpen, modalClose} = useModal({
         title: "",

--- a/src/components/video/useScrapModal/index.tsx
+++ b/src/components/video/useScrapModal/index.tsx
@@ -20,6 +20,8 @@ interface Props {
     id: number
 }
 
+
+// [SugarSyrup] @TODO: PM에서 대규모 수정 중
 function useScrapModal({id}: Props) {
     const [data, setScrapModalData] = useState<data>();
     const [isScrapCreate, setIsScrapCreate] = useState<boolean>(false);

--- a/src/components/video/useScrapModal/index.tsx
+++ b/src/components/video/useScrapModal/index.tsx
@@ -16,7 +16,11 @@ type data = {
     }[]
 }
 
-function useScrapModal() {
+interface Props {
+    id: number
+}
+
+function useScrapModal({id}: Props) {
     const [data, setScrapModalData] = useState<data>();
     const [isScrapCreate, setIsScrapCreate] = useState<boolean>(false);
     const {Modal, modalOpen, modalClose} = useModal({

--- a/src/hooks/useAlert/style.ts
+++ b/src/hooks/useAlert/style.ts
@@ -45,7 +45,7 @@ export const Alert = styled.div<{isOpen: boolean}>`
 
     position:absolute;
     bottom:100px;
-    left: 32px;
+    left: 12px;
 
     animation:${({isOpen}) => isOpen ? fadeIn : fadeOut} 0.15s ease-out;
     display:${({isOpen}) => isOpen ? "flex" : "none"};

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -14,8 +14,6 @@ import PageHeader from "../../components/common/PageHeader";
 import PageTemplate from "../../components/common/PageTemplate";
 import Typography from "../../components/common/Typography";
 import PlaceOperateTime from "../../components/journal/PlaceOperateTime";
-import useScrapModal from "../../components/video/useScrapModal";
-import useCourseModal from "../../components/video/useCourseModal";
 import PlaceGoogleMap from "../../components/journal/GoogleMap";
 import { get, post } from "../../utils/api";
 

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -30,8 +30,8 @@ type TData = {
     opening_hours: string,
     website: string,
     image: string[],
-    latitude: number,
-    longitude: number,
+    latitude: string,
+    longitude: string,
 }
 
 
@@ -45,6 +45,7 @@ function PlacePage() {
     useEffect(() => {
         get<TData>(`${import.meta.env.VITE_BASE_URL}/place/${id}`)
             .then((response) => {
+                console.log(response.data);
                 setData(response.data)
             });
     }, [])
@@ -75,8 +76,7 @@ function PlacePage() {
                                     const reqData = new FormData();
                                     reqData.append('placeId', id as string);
                                     reqData.append('image', e.currentTarget.value);
-
-                                    // [SugarSyrup] @TODO: 해당 이미지 등록하는 부분 백엔드 미 배포로 테스트 불가
+                                    
                                     post(`${import.meta.env.VITE_BASE_URL}/place/image`, reqData, {
                                         headers: {
                                             "Content-Type":"multipart/form-data"
@@ -113,15 +113,14 @@ function PlacePage() {
                                 <S.InfomationLink to={data.website}>인스타그램</S.InfomationLink>
                             </S.InfomationItem>
                         </S.InfomationList>
-                        {/* [SugarSyrup] @TODO: lat,lng 좌표 백엔드에서 받아오는 부분 아직 베포 안되서 test 진행 불가 */}
                         <PlaceGoogleMap
                             height="270px"
                             center={{
-                                lat: data.latitude,
-                                lng: data.longitude
+                                lat: Number(data.latitude),
+                                lng: Number(data.longitude)
                             }} markers={[{
-                                lat: data.latitude,
-                                lng: data.longitude
+                                lat: Number(data.latitude),
+                                lng: Number(data.longitude)
                             }]}
                         />
                         <S.Buttons>

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -18,6 +18,7 @@ import PlaceGoogleMap from "../../components/journal/GoogleMap";
 import { get, post } from "../../utils/api";
 
 import * as S from "./style";
+import useAlert from "../../hooks/useAlert";
 
 type TData = {
     region: string,
@@ -38,7 +39,11 @@ function PlacePage() {
     const {id} = useParams();
     const [data, setData] = useState<TData>();
     const [imageURL, setImageURL] = useState<string>("");
-    //const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal({id: Number(id)});
+
+    const [alertMessage, setAlertMessage] = useState<string>("");
+    const {Alert, alertOpen} = useAlert({
+        Content: <Typography.Body size="lg" color="white">{alertMessage}</Typography.Body>
+    });
 
     useEffect(() => {
         get<TData>(`${import.meta.env.VITE_BASE_URL}/place/${id}`)
@@ -50,6 +55,7 @@ function PlacePage() {
 
     return(
         <PageTemplate header={<PageHeader LeftItem={<BackButton />}><S.TopBarText>{data && data.name}</S.TopBarText></PageHeader>} nav={false}>
+            <Alert />
             {
                 data !== undefined && 
                 <S.ContentContainer>
@@ -124,7 +130,19 @@ function PlacePage() {
                                 <CalendarAddIcon />
                                 <Typography.Label size="lg">내 일정에 추가하기</Typography.Label>
                             </S.Button>
-                            <S.Button>
+                            <S.Button onClick={() => {
+                                post<{message: string}>('/folder/scrap/place', {
+                                    placeId: id
+                                }).then((response) => {
+                                    if(response.data.message === "Create Success") {
+                                        setAlertMessage(`${data.name}가 스크랩 되었습니다.`);
+                                    } else {
+                                        setAlertMessage(`${data.name}를 스크랩에서 삭제했습니다.`);
+                                    }
+
+                                    alertOpen();
+                                })
+                            }}>
                                 <ScrapIcon />
                                 <Typography.Label size="lg">장소 스크랩에 저장</Typography.Label>
                             </S.Button>

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import LocationIcon from "../../assets/icons/location.svg?react";
 import PhoneIcon from "../../assets/icons/phone.svg?react";
@@ -36,11 +36,11 @@ type TData = {
 
 
 function PlacePage() {
+    const navigate = useNavigate();
     const {id} = useParams();
     const [data, setData] = useState<TData>();
     const [imageURL, setImageURL] = useState<string>("");
-    const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal({id: Number(id)});
-    const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal({id: Number(id)});
+    //const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal({id: Number(id)});
 
     useEffect(() => {
         get<TData>(`${import.meta.env.VITE_BASE_URL}/place/${id}`)
@@ -55,8 +55,6 @@ function PlacePage() {
             {
                 data !== undefined && 
                 <S.ContentContainer>
-                    <CourseModal />
-                    <ScrapModal />
                     {
                         data.image.length === 0 && imageURL === ""?
                         <S.ImgRegistContainer>
@@ -124,11 +122,11 @@ function PlacePage() {
                             }]}
                         />
                         <S.Buttons>
-                            <S.Button onClick={() => courseModalOpen()}>
+                            <S.Button onClick={() => {navigate(`/mytrip/place/${id}`)}}>
                                 <CalendarAddIcon />
                                 <Typography.Label size="lg">내 일정에 추가하기</Typography.Label>
                             </S.Button>
-                            <S.Button onClick={() => scrapModalOpen()}>
+                            <S.Button>
                                 <ScrapIcon />
                                 <Typography.Label size="lg">장소 스크랩에 저장</Typography.Label>
                             </S.Button>

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -1,4 +1,5 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
 
 import LocationIcon from "../../assets/icons/location.svg?react";
 import PhoneIcon from "../../assets/icons/phone.svg?react";
@@ -6,92 +7,134 @@ import TimeIcon from "../../assets/icons/clock.svg?react";
 import LinkIcon from "../../assets/icons/web.svg?react";
 import CalendarAddIcon from "../../assets/icons/calendar_add_border.svg?react";
 import ScrapIcon from "../../assets/icons/bookmark.svg?react"
+import PlusIcon from "../../assets/icons/plus_circle_blue.svg?react";
 
 import BackButton from "../../components/common/BackButton";
 import PageHeader from "../../components/common/PageHeader";
 import PageTemplate from "../../components/common/PageTemplate";
+import Typography from "../../components/common/Typography";
 import PlaceOperateTime from "../../components/journal/PlaceOperateTime";
 import useScrapModal from "../../components/video/useScrapModal";
 import useCourseModal from "../../components/video/useCourseModal";
+import PlaceGoogleMap from "../../components/journal/GoogleMap";
+import { get, post } from "../../utils/api";
 
 import * as S from "./style";
-import PlaceGoogleMap from "../../components/journal/GoogleMap";
-import Typography from "../../components/common/Typography";
 
-
-
-const data = {
-    "region": "부산",
-    "name": "174센치한남",
-    "theme": "술집",
-    "address": "부산광역시 중구 광복중앙로 22",
-    "number": "051-255-0174",
-    "opening_hours": "월요일: 오후 5:00 ~ 오전 2:00\n화요일: 오후 5:00 ~ 오전 2:00\n수요일: 오후 5:00 ~ 오전 2:00\n목요일: 오후 5:00 ~ 오전 2:00\n금요일: 오후 5:00 ~ 오전 2:00\n토요일: 오후 5:00 ~ 오전 2:00\n일요일: 오후 5:00 ~ 오전 2:00",
-    "website": "",
-    "image": []
+type TData = {
+    region: string,
+    name: string,
+    theme: string,
+    address: string,
+    number: string,
+    opening_hours: string,
+    website: string,
+    image: string[],
+    // latitude: number,
+    // longitude: number,
 }
 
-function PlacePage() {
-    const thumbnailWrapperRef = useRef<HTMLDivElement>(null);
-    const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal();
-    const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal();
 
-    // useEffect(() => {
-    //     get(`${import.meta.env.BASE_URL}place/1`)
-    //         .then((response) => {console.log(response)});
-    // }, [])
+function PlacePage() {
+    const {id} = useParams();
+    const [data, setData] = useState<TData>();
+    const [imageURL, setImageURL] = useState<string>("");
+    const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal({id: Number(id)});
+    const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal({id: Number(id)});
+
+    useEffect(() => {
+        get<TData>(`${import.meta.env.VITE_BASE_URL}/place/${id}`)
+            .then((response) => {
+                setData(response.data)
+            });
+    }, [])
 
     return(
-        <PageTemplate header={<PageHeader LeftItem={<BackButton />}><S.TopBarText>모구모구 제과점</S.TopBarText></PageHeader>} nav={false}>
+        <PageTemplate header={<PageHeader LeftItem={<BackButton />}><S.TopBarText>{data && data.name}</S.TopBarText></PageHeader>} nav={false}>
             <CourseModal />
             <ScrapModal />
-            <S.ThumbnailWrapper ref={thumbnailWrapperRef}>
-                {
-                    data.image.length === 0 ?
-                    <></>
-                    :
-                    data.image.map((img) => <img src={img} />)
-                }
-            </S.ThumbnailWrapper>
-            <S.ThumbnailEmpty padding={thumbnailWrapperRef.current?.offsetHeight}/>
-            <S.InfomationList>
-                <S.InfomationItem>
-                    <LocationIcon />
-                    <S.InfomationText>{data.address}</S.InfomationText>
-                </S.InfomationItem>
-                <S.InfomationItem>
-                    <PhoneIcon />
-                    <S.InfomationText>{data.number}</S.InfomationText>
-                </S.InfomationItem>
-                <S.InfomationItem>
-                    <TimeIcon />
-                    <PlaceOperateTime opening_hours={data.opening_hours}/>
-                </S.InfomationItem>
-                <S.InfomationItem>
-                    <LinkIcon />
-                    <S.InfomationLink to={data.website}>인스타그램</S.InfomationLink>
-                </S.InfomationItem>
-            </S.InfomationList>
-            <PlaceGoogleMap
-                height="270px"
-                center={{
-                    lat: 37,
-                    lng: 126
-                }} markers={[{
-                    lat: 37,
-                    lng: 126
-                }]}
-            />
-            <S.Buttons>
-                <S.Button onClick={() => courseModalOpen()}>
-                    <CalendarAddIcon />
-                    <Typography.Label size="lg">내 일정에 추가하기</Typography.Label>
-                </S.Button>
-                <S.Button onClick={() => scrapModalOpen()}>
-                    <ScrapIcon />
-                    <Typography.Label size="lg">장소 스크랩에 저장</Typography.Label>
-                </S.Button>
-            </S.Buttons>
+            {
+                data !== undefined && 
+                <S.ContentContainer>
+                    {
+                        data.image.length === 0 && imageURL === ""?
+                        <S.ImgRegistContainer>
+                            <label htmlFor="placeImgRegist">
+                                <PlusIcon/>
+                            </label>
+                            <input id="placeImgRegist" type="file" accept="image/*" onInput={(e) => {
+                                if(e.currentTarget.files){
+                                    const file = e.currentTarget.files[0];
+                                    const reader = new FileReader();
+                      
+                                    reader.readAsDataURL(file);
+                                    reader.onloadend = () => {
+                                      setImageURL(reader.result as string);
+                                    }
+
+                                    const reqData = new FormData();
+                                    reqData.append('placeId', id as string);
+                                    reqData.append('image', e.currentTarget.value);
+
+                                    post(`${import.meta.env.VITE_BASE_URL}/place/image`, reqData, {
+                                        headers: {
+                                            "Content-Type":"multipart/form-data"
+                                        }
+                                    })
+                                }
+                            }} />
+                            <Typography.Title size="md" color="inherit">이 장소의 첫 번째 사진을 등록해주세요!</Typography.Title>
+                        </S.ImgRegistContainer>
+                        :
+                        <S.ImgSlider>
+                            {data.image.map((img) => <img src={img} />)}
+                        </S.ImgSlider>
+                    }
+                    {imageURL && <img src={imageURL} />}
+                    <S.ContentList>
+                        <S.InfomationList>
+                            <S.InfomationItem>
+                                <LocationIcon />
+                                <S.InfomationText>{data.address}</S.InfomationText>
+                            </S.InfomationItem>
+                            <S.InfomationItem>
+                                <PhoneIcon />
+                                <S.InfomationText>{data.number}</S.InfomationText>
+                            </S.InfomationItem>
+                            { data.opening_hours !== "" &&
+                                <S.InfomationItem>
+                                    <TimeIcon />
+                                    <PlaceOperateTime opening_hours={data.opening_hours}/>
+                                </S.InfomationItem>
+                            }
+                            <S.InfomationItem>
+                                <LinkIcon />
+                                <S.InfomationLink to={data.website}>인스타그램</S.InfomationLink>
+                            </S.InfomationItem>
+                        </S.InfomationList>
+                        <PlaceGoogleMap
+                            height="270px"
+                            center={{
+                                lat:123,
+                                lng: 123
+                            }} markers={[{
+                                lat: 123,
+                                lng: 123
+                            }]}
+                        />
+                        <S.Buttons>
+                            <S.Button onClick={() => courseModalOpen()}>
+                                <CalendarAddIcon />
+                                <Typography.Label size="lg">내 일정에 추가하기</Typography.Label>
+                            </S.Button>
+                            <S.Button onClick={() => scrapModalOpen()}>
+                                <ScrapIcon />
+                                <Typography.Label size="lg">장소 스크랩에 저장</Typography.Label>
+                            </S.Button>
+                        </S.Buttons>
+                    </S.ContentList>
+                </S.ContentContainer>
+            }
         </PageTemplate>
     )
 }

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -76,6 +76,7 @@ function PlacePage() {
                                     reqData.append('placeId', id as string);
                                     reqData.append('image', e.currentTarget.value);
 
+                                    // [SugarSyrup] @TODO: 해당 이미지 등록하는 부분 백엔드 미 배포로 테스트 불가
                                     post(`${import.meta.env.VITE_BASE_URL}/place/image`, reqData, {
                                         headers: {
                                             "Content-Type":"multipart/form-data"
@@ -112,6 +113,7 @@ function PlacePage() {
                                 <S.InfomationLink to={data.website}>인스타그램</S.InfomationLink>
                             </S.InfomationItem>
                         </S.InfomationList>
+                        {/* [SugarSyrup] @TODO: lat,lng 좌표 백엔드에서 받아오는 부분 아직 베포 안되서 test 진행 불가 */}
                         <PlaceGoogleMap
                             height="270px"
                             center={{

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -30,8 +30,8 @@ type TData = {
     opening_hours: string,
     website: string,
     image: string[],
-    // latitude: number,
-    // longitude: number,
+    latitude: number,
+    longitude: number,
 }
 
 
@@ -51,11 +51,11 @@ function PlacePage() {
 
     return(
         <PageTemplate header={<PageHeader LeftItem={<BackButton />}><S.TopBarText>{data && data.name}</S.TopBarText></PageHeader>} nav={false}>
-            <CourseModal />
-            <ScrapModal />
             {
                 data !== undefined && 
                 <S.ContentContainer>
+                    <CourseModal />
+                    <ScrapModal />
                     {
                         data.image.length === 0 && imageURL === ""?
                         <S.ImgRegistContainer>
@@ -115,11 +115,11 @@ function PlacePage() {
                         <PlaceGoogleMap
                             height="270px"
                             center={{
-                                lat:123,
-                                lng: 123
+                                lat: data.latitude,
+                                lng: data.longitude
                             }} markers={[{
-                                lat: 123,
-                                lng: 123
+                                lat: data.latitude,
+                                lng: data.longitude
                             }]}
                         />
                         <S.Buttons>

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -16,74 +16,82 @@ import useCourseModal from "../../components/video/useCourseModal";
 
 import * as S from "./style";
 import PlaceGoogleMap from "../../components/journal/GoogleMap";
+import Typography from "../../components/common/Typography";
+
+
+
+const data = {
+    "region": "부산",
+    "name": "174센치한남",
+    "theme": "술집",
+    "address": "부산광역시 중구 광복중앙로 22",
+    "number": "051-255-0174",
+    "opening_hours": "월요일: 오후 5:00 ~ 오전 2:00\n화요일: 오후 5:00 ~ 오전 2:00\n수요일: 오후 5:00 ~ 오전 2:00\n목요일: 오후 5:00 ~ 오전 2:00\n금요일: 오후 5:00 ~ 오전 2:00\n토요일: 오후 5:00 ~ 오전 2:00\n일요일: 오후 5:00 ~ 오전 2:00",
+    "website": "",
+    "image": []
+}
 
 function PlacePage() {
     const thumbnailWrapperRef = useRef<HTMLDivElement>(null);
     const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal();
     const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal();
 
+    // useEffect(() => {
+    //     get(`${import.meta.env.BASE_URL}place/1`)
+    //         .then((response) => {console.log(response)});
+    // }, [])
+
     return(
         <PageTemplate header={<PageHeader LeftItem={<BackButton />}><S.TopBarText>모구모구 제과점</S.TopBarText></PageHeader>} nav={false}>
             <CourseModal />
             <ScrapModal />
             <S.ThumbnailWrapper ref={thumbnailWrapperRef}>
-                <img src={"a.png"} />
+                {
+                    data.image.length === 0 ?
+                    <></>
+                    :
+                    data.image.map((img) => <img src={img} />)
+                }
             </S.ThumbnailWrapper>
             <S.ThumbnailEmpty padding={thumbnailWrapperRef.current?.offsetHeight}/>
             <S.InfomationList>
                 <S.InfomationItem>
                     <LocationIcon />
-                    <S.InfomationText>부산광역시 수영구 광안로49번길 27</S.InfomationText>
+                    <S.InfomationText>{data.address}</S.InfomationText>
                 </S.InfomationItem>
                 <S.InfomationItem>
                     <PhoneIcon />
-                    <S.InfomationText>070-8772-5959</S.InfomationText>
+                    <S.InfomationText>{data.number}</S.InfomationText>
                 </S.InfomationItem>
                 <S.InfomationItem>
                     <TimeIcon />
-                    <PlaceOperateTime />
+                    <PlaceOperateTime opening_hours={data.opening_hours}/>
                 </S.InfomationItem>
                 <S.InfomationItem>
                     <LinkIcon />
-                    <S.InfomationLink to="/">인스타그램</S.InfomationLink>
+                    <S.InfomationLink to={data.website}>인스타그램</S.InfomationLink>
                 </S.InfomationItem>
             </S.InfomationList>
-            <PlaceGoogleMap center={{
-                lat: 37,
-                lng: 126
-            }} markers={[{
-                lat: 37,
-                lng: 126
-            }]}/>
+            <PlaceGoogleMap
+                height="270px"
+                center={{
+                    lat: 37,
+                    lng: 126
+                }} markers={[{
+                    lat: 37,
+                    lng: 126
+                }]}
+            />
             <S.Buttons>
                 <S.Button onClick={() => courseModalOpen()}>
                     <CalendarAddIcon />
-                    <span>내 일정에 추가하기</span>
+                    <Typography.Label size="lg">내 일정에 추가하기</Typography.Label>
                 </S.Button>
                 <S.Button onClick={() => scrapModalOpen()}>
                     <ScrapIcon />
-                    <span>장소 스크랩에 저장</span>
+                    <Typography.Label size="lg">장소 스크랩에 저장</Typography.Label>
                 </S.Button>
             </S.Buttons>
-            <S.RecommendArticleTitle><strong>"모구모구 과자점"</strong>을 포함한 게시글이 있어요</S.RecommendArticleTitle>
-            <S.RecommendArticleList>
-                <S.RecommendArticleItem>
-                    <img src="a.png" />
-                    <span>10년지기 친구들과 다녀온 2박3일 123123123</span>
-                    <span>여기가 그 유명한 <strong>모구모구 과자점</strong>이였어요!</span>
-                </S.RecommendArticleItem>
-                <S.RecommendArticleItem>
-                    <img src="a.png" />
-                    <span>10년지기 친구들과 다녀온 2박3일 123123123</span>
-                    <span>여기가 그 유명한 <strong>모구모구 과자점</strong>이였어요!</span>
-                </S.RecommendArticleItem>
-                <S.RecommendArticleItem>
-                    <img src="a.png" />
-                    <span>10년지기 친구들과 다녀온 2박3일 123123123</span>
-                    <span>여기가 그 유명한 <strong>모구모구 과자점</strong>이였어요!</span>
-                </S.RecommendArticleItem>
-            </S.RecommendArticleList>
-            <S.ThumbnailEmpty padding={50}/>
         </PageTemplate>
     )
 }

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -105,7 +105,7 @@ export const Buttons = styled.div`
 
 export const Button = styled.div`
     width:100%;
-    padding:8px 32px;
+    padding:9px 27px;
 
     border-radius:6px;
     background-color:${({theme}) => theme.gray05};
@@ -120,84 +120,7 @@ export const Button = styled.div`
         height:18px;
 
         path {
-            fill:${({theme}) => theme.gray};
-        }
-    }
-
-    span {
-        color: ${({theme}) => theme.gray};
-        font-size: 11px;
-        font-weight: 400;
-        line-height: 22px;
-    }
-`
-
-export const RecommendArticleTitle = styled.span`
-    display:block;
-    margin-top:30px;
-
-    color: ${({theme}) => theme.black};
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 22px;
-
-    strong {
-        color:${({theme}) => theme.main};
-    }
-`
-
-export const RecommendArticleList = styled.div`
-    width:100%;
-    overflow-x:scroll;
-
-    margin-top:16px;
-
-    display:flex;
-    gap:20px;
-
-    -ms-overflow-style: none;
-    &::-webkit-scrollbar{
-        display:none;
-    }
-`
-
-export const RecommendArticleItem = styled.div`
-    display:flex;
-    flex-direction:column;
-    align-items:flex-start;
-    gap:8px;
-
-    img {
-        width:250px;
-        height:170px;
-        object-fit:contain;
-        border-radius:10px;
-    }
-
-    span{
-        color: ${({theme}) => theme.black};
-        font-size: 14px;
-        font-weight: 600;
-        line-height: 18px;
-        letter-spacing: 0.2px;
-
-        display:block;
-        width:207px;
-        white-space:nowrap;
-        overflow:hidden;
-        text-overflow:ellipsis;
-    }
-
-    span:last-child{
-        color: ${({theme}) => theme.gray01};
-        font-size: 12px;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 9px;
-        letter-spacing: 0.2px;
-
-        strong {
-            color: ${({theme}) => theme.main};
+            fill:#A6A6A6;
         }
     }
 `

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -29,7 +29,7 @@ export const TopBarText = styled.span`
     padding-top:14px;
 `
 
-export const ThumbnailWrapper = styled.div`
+export const ContentContainer = styled.div`
     width:100%;
 
     position:absolute;
@@ -42,10 +42,60 @@ export const ThumbnailWrapper = styled.div`
     }
 `
 
-export const ThumbnailEmpty = styled.div<{padding?: number}>`
+export const ImgSlider = styled.div`
     width:100%;
-    padding-top:${({padding}) => padding + "px"};
-`   
+    overflow:auto;
+    position:relative;
+
+    display:flex;
+    justify-content:flex-start;
+    align-items:center;
+    scroll-snap-type: x mandatory;
+
+    img {
+        width:100%;
+        height:300px;
+        scroll-snap-align: start;
+        object-fit:contain;
+        flex-shrink:0;
+        background-color:yellow;
+    }
+
+    &::-webkit-scrollbar {
+        display: none;
+        scrollbar-width: none;
+    }
+`
+
+export const ImgRegistContainer = styled.div`
+    width:100%;
+    height:200px;
+
+    background-color: #E4E4E4;
+    color: #A6A6A6;
+
+    display:flex;
+    flex-direction:column;
+    justify-content:center;
+    align-items:center;
+    gap:8px;
+
+    svg{
+        width:56px;
+        height:56px;
+        cursor:pointer;
+    }
+
+    input {
+        display:none;
+    }
+`;
+
+export const ContentList = styled.div`
+    width:100%;
+    padding-left:20px;
+    padding-right:20px;
+`
 
 export const InfomationList = styled.ol`
     width:100%;
@@ -69,7 +119,7 @@ export const InfomationItem = styled.li`
     svg {
         width:20px;
         height:20px;
-        path: {
+        path {
             fill:${({theme}) => theme.gray};
         }
     }

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -35,11 +35,6 @@ export const ContentContainer = styled.div`
     position:absolute;
     top:0px;
     left:0px;
-
-    img {
-        width:100%;
-        object-fit:contain;
-    }
 `
 
 export const ImgSlider = styled.div`

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -54,11 +54,9 @@ export const ImgSlider = styled.div`
 
     img {
         width:100%;
-        height:300px;
         scroll-snap-align: start;
         object-fit:contain;
         flex-shrink:0;
-        background-color:yellow;
     }
 
     &::-webkit-scrollbar {

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -157,6 +157,7 @@ export const Button = styled.div`
     justify-content:center;
     align-items:center;
     gap:10px;
+    cursor:pointer;
 
     svg{
         width:18px;

--- a/src/pages/auth/LoginPage/index.tsx
+++ b/src/pages/auth/LoginPage/index.tsx
@@ -28,7 +28,7 @@ type loginResponse = {
 
 async function login() {
   const response = await post<loginResponse>(
-    `${import.meta.env.VITE_BASE_URL}user/app/login`,
+    `${import.meta.env.VITE_BASE_URL}/user/app/login`,
     {
       uid: 1234321,
       provider: "google",

--- a/src/pages/journal/PostPage/index.tsx
+++ b/src/pages/journal/PostPage/index.tsx
@@ -21,9 +21,9 @@ import * as S from "./style";
 function PostPage() {
     const navigate = useNavigate();
 
-    const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal();
+    const {CourseModal, courseModalOpen, courseModalClose, setCourseModalData} = useCourseModal({id:1});
     const {PlaceModal, placeModalOpen, placeModalClose, setPlaceModalData} = usePlaceModal();
-    const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal();
+    const {ScrapModal, scrapModalOpen, scrapModalClose, setScrapModalData} = useScrapModal({id:1});
 
     const {ScrapAlert, scrapAlertOpen, scrapAlertClose} = useScrapAlert({
         onClick: scrapModalOpen

--- a/src/pages/mytrip/DatesSelectPage/index.tsx
+++ b/src/pages/mytrip/DatesSelectPage/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import * as S from "./style";
 import XIcon from "../../../assets/icons/grayx.svg?react";
@@ -8,12 +8,13 @@ import Heading from "../../../components/common/Heading";
 import CalendarContainer from "../../../components/mytrip/CalendarContainer";
 
 function MyTripDatesSelectPage() {
+  const navigate = useNavigate();
   return (
     <>
       <PageTemplate nav={false}>
-        <Link to="/mytrip" style={{ cursor: "pointer" }}>
+        <div style={{ cursor: "pointer" }} onClick={() => { navigate(-1) }}>
           <XIcon />
-        </Link>
+        </div>
         <S.HeadingWrapper>
           <Heading size="sm">여행 날짜를 선택해주세요.</Heading>
         </S.HeadingWrapper>

--- a/src/pages/mytrip/MyTripPage/index.tsx
+++ b/src/pages/mytrip/MyTripPage/index.tsx
@@ -14,10 +14,12 @@ import * as S from "./style";
 import { Link } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 import { datesState } from "../../../recoil/mytrip/createData";
+import { createTravelState } from "../../../recoil/mytrip/createTravelState";
 
 function MyTripPage() {
   const FLAG = false;
   const setDates = useSetRecoilState(datesState);
+  const setCreactTravelState = useSetRecoilState(createTravelState);
 
   function initializeDates() {
     setDates({
@@ -55,7 +57,10 @@ function MyTripPage() {
               highlight={false}
             />
           </S.ScheduleCardContainer>
-          <Link to="/mytrip/create" onClick={() => initializeDates()}>
+          <Link to="/mytrip/create" onClick={() => {
+            setCreactTravelState("create");
+            initializeDates()
+          }}>
             <S.CreateMyTripScheduleBtn>
               <CirclePlusIcon />
               새로운 여행 일정 만들기
@@ -82,7 +87,10 @@ function MyTripPage() {
             </S.CreateMyTripTextWrapper>
             <S.SeperateLine />
             <S.ButtonWrapper>
-              <Link to="/mytrip/create" onClick={() => initializeDates()}>
+              <Link to="/mytrip/create" onClick={() => {
+                setCreactTravelState("create");
+                initializeDates()
+              }}>
                 <Button size="sm" type="text">
                   <S.ButtonText>
                     일정 생성하기
@@ -132,7 +140,10 @@ function MyTripPage() {
         />
       </S.ContentContainer>
 
-      <Link to="/mytrip/create" onClick={() => initializeDates()}>
+      <Link to="/mytrip/create" onClick={() => {
+        setCreactTravelState("create");
+        initializeDates()
+      }}>
         <S.FloatingBtnWrapper>
           <BlueCirclePlusIcon />
         </S.FloatingBtnWrapper>

--- a/src/pages/mytrip/PlaceAddPage/index.tsx
+++ b/src/pages/mytrip/PlaceAddPage/index.tsx
@@ -102,6 +102,7 @@ const PlaceAddPage = () => {
                         <InfomationIcon />
                         <S.PopupTextContainer>
                             <Typography.Headline size="sm">지역윽 추가하시겠어요?</Typography.Headline>
+                            {/* [SugarSyrup] @TODO: 백엔드 response가 현재 미 완료, 추후 확인 후 반영 */}
                             {/* <Typography.Body size="lg" color="inherit">선택하신 여행 장소는 {data.filter((item) => item.id === currentSelectedItem.id)[0].location}을 벗어나요.</Typography.Body> */}
                             <Typography.Body size="lg" color="inherit">{placeData?.name}도 여행 계획에 추가하시겠어요?</Typography.Body>
                             <Typography.Body size="md" color="#FA5252">*지역을 추가하지 않으면, 해당 장소도 추가되지 않아요.</Typography.Body>
@@ -156,6 +157,7 @@ const PlaceAddPage = () => {
                 </S.CreateNewTravelButton>
             </S.MyTravelHeader>
             <S.MyTravelList>
+                {/* [SugarSyrup] @TODO: 백엔드 response가 현재 미 완료, 추후 확인 후 반영 */}
                 {
                     data.map((item) => 
                         <LocationAddItem {...item} currentSelectedItemId={currentSelectedItem.id} setCurrentSelectedItem={setCurrentSelectedItem}/>

--- a/src/pages/mytrip/PlaceAddPage/index.tsx
+++ b/src/pages/mytrip/PlaceAddPage/index.tsx
@@ -1,0 +1,83 @@
+import { useNavigate, useParams } from "react-router-dom";
+
+import XIcon from "../../../assets/icons/x.svg?react";
+import PageHeader from "../../../components/common/PageHeader";
+import PageTemplate from "../../../components/common/PageTemplate";
+import Typography from "../../../components/common/Typography";
+
+import * as S from "./style";
+import { useEffect, useState } from "react";
+import LocationAddItem from "../../../components/mytrip/LocationAddItem";
+import { get } from "../../../utils/api";
+
+export interface TMyTravelItem {
+    "id": number,
+    "name": string,
+    "departureDate": string,
+    "arrivalDate": string,
+    "location": string[],
+    "days": {
+        "day": number,
+        "date": string,
+        "dayOfWeek": string,
+    }[],
+    "thumbnailURL": string,
+}
+
+const PlaceAddPage = () => {
+    const {id} = useParams();
+    const navigate = useNavigate();
+
+    const [data, setData] = useState<TMyTravelItem[]>([]);
+    const [currentSelectedItem, setCurrentSelectedItem] = useState<{id: number, day?: number}>({id: -1});
+
+    useEffect(() => {
+        get<TMyTravelItem[]>(`/my-travel/community/place/${id}`)
+            .then((response) => {
+                setData(response.data);
+            })
+    }, [])
+
+    return (
+        <PageTemplate header={<PageHeader 
+            LeftItem={
+                <S.DeleteIcon onClick={() => {
+                    navigate(-1);
+                }}>
+                    <XIcon />
+                </S.DeleteIcon>
+            } />
+        } nav={
+            <S.Footer>
+                <S.Button 
+                    isActive={typeof currentSelectedItem.day === 'number'} 
+                    onClick={() => {
+                        
+                    }}
+                >
+                    <Typography.Title size="lg" color="inherit" >이 일정에 장소를 추가할게요!</Typography.Title>
+                </S.Button>
+            </S.Footer>
+        }>
+            <S.Header>
+                <Typography.Headline size="md">장소를 추가할</Typography.Headline>
+                <Typography.Headline size="md">여행 일정을 선택해주세요.</Typography.Headline>
+            </S.Header>
+            <S.MyTravelHeader>
+                <Typography.Title size="lg">{data.length !== 0 && "나의 다가오는 여행"}</Typography.Title>
+                <S.CreateNewTravelButton onClick={() => {navigate('/mytrip/create')}}>
+                    <Typography.Label size="lg" color="inherit">새로운 여행 일정 만들기</Typography.Label>
+                </S.CreateNewTravelButton>
+            </S.MyTravelHeader>
+            <S.MyTravelList>
+                {
+                    data.map((item) => 
+                        <LocationAddItem {...item} currentSelectedItemId={currentSelectedItem.id} setCurrentSelectedItem={setCurrentSelectedItem}/>
+                    )
+                }
+            </S.MyTravelList>
+        </PageTemplate>
+    );
+};
+
+export default PlaceAddPage;

--- a/src/pages/mytrip/PlaceAddPage/index.tsx
+++ b/src/pages/mytrip/PlaceAddPage/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from "react-router-dom";
 
+import InfomationIcon from "../../../assets/icons/exclamation_circle.svg?react";
 import XIcon from "../../../assets/icons/x.svg?react";
 import PageHeader from "../../../components/common/PageHeader";
 import PageTemplate from "../../../components/common/PageTemplate";
@@ -8,7 +9,9 @@ import Typography from "../../../components/common/Typography";
 import * as S from "./style";
 import { useEffect, useState } from "react";
 import LocationAddItem from "../../../components/mytrip/LocationAddItem";
-import { get } from "../../../utils/api";
+import { get, post } from "../../../utils/api";
+import usePopup from "../../../hooks/usePopup";
+import useAlert from "../../../hooks/useAlert";
 
 export interface TMyTravelItem {
     "id": number,
@@ -29,12 +32,29 @@ const PlaceAddPage = () => {
     const navigate = useNavigate();
 
     const [data, setData] = useState<TMyTravelItem[]>([]);
+    const [placeData, setPlaceData] = useState<{
+        region: string,
+        name: string,
+    }>();
     const [currentSelectedItem, setCurrentSelectedItem] = useState<{id: number, day?: number}>({id: -1});
+
+    const {Popup, popupOpen, popupClose} = usePopup();
+    const {Alert, alertOpen, alertClose} = useAlert({
+        Content: <Typography.Body size="lg" color="white">장소가 추가되었습니다.</Typography.Body>
+    });
 
     useEffect(() => {
         get<TMyTravelItem[]>(`/my-travel/community/place/${id}`)
             .then((response) => {
                 setData(response.data);
+            })
+
+        get<{
+            region: string,
+            name: string,
+        }>(`/place/${id}`)
+            .then((response) => {
+                setPlaceData(response.data);
             })
     }, [])
 
@@ -52,13 +72,79 @@ const PlaceAddPage = () => {
                 <S.Button 
                     isActive={typeof currentSelectedItem.day === 'number'} 
                     onClick={() => {
-                        
+                        if(currentSelectedItem.id === -1) return;
+                        if(currentSelectedItem.day === undefined) return;
+
+                        post<{
+                            id: number,
+                            name: number,
+                        }>(`/my-travel/community/place`, {
+                            placeId: id,
+                            myTravelId: currentSelectedItem.id,
+                            day: currentSelectedItem.day
+                        }).then((response) => {
+                            if(response.status === 400) {
+                                popupOpen();
+                            } else {
+                                alertOpen();
+                            }
+                        })
                     }}
                 >
                     <Typography.Title size="lg" color="inherit" >이 일정에 장소를 추가할게요!</Typography.Title>
                 </S.Button>
             </S.Footer>
         }>
+            <Alert />
+            <Popup>
+                <S.PopupWrapper>
+                    <S.PopupContentsContainer>
+                        <InfomationIcon />
+                        <S.PopupTextContainer>
+                            <Typography.Headline size="sm">지역윽 추가하시겠어요?</Typography.Headline>
+                            {/* <Typography.Body size="lg" color="inherit">선택하신 여행 장소는 {data.filter((item) => item.id === currentSelectedItem.id)[0].location}을 벗어나요.</Typography.Body> */}
+                            <Typography.Body size="lg" color="inherit">{placeData?.name}도 여행 계획에 추가하시겠어요?</Typography.Body>
+                            <Typography.Body size="md" color="#FA5252">*지역을 추가하지 않으면, 해당 장소도 추가되지 않아요.</Typography.Body>
+                        </S.PopupTextContainer>
+                        <S.PopupButtons>
+                            <S.PopupButton isMain={false} onClick={() => {
+                                popupClose();
+                            }}>
+                                <Typography.Body size="lg" color="inherit">아니요</Typography.Body>
+                            </S.PopupButton>
+                            <S.PopupButton isMain={true} onClick={() => {
+                                post<{message: string}>('/my-travel/location', {
+                                    myTravelId: currentSelectedItem.id,
+                                    location: placeData?.region
+                                }).then((response) => {
+                                    if(response.status === 201) {
+                                        post<{
+                                            id: number,
+                                            name: number,
+                                        }>(`/my-travel/community/place`, {
+                                            placeId: id,
+                                            myTravelId: currentSelectedItem.id,
+                                            day: currentSelectedItem.day
+                                        }).then((response) => {
+                                            if(response.status === 400) {
+                                                popupOpen();
+                                            } else {
+                                                popupClose();
+                                                alertOpen();
+                                            }
+                                        })
+                                    } else {    
+                                        window.alert("이미 내 여행 지역에 추가되어 있습니다.")
+                                    }
+                                })
+                                popupClose();
+                            }}>
+                                <Typography.Body size="lg" color="inherit">네, 추가할게요</Typography.Body>
+                            </S.PopupButton>
+                        </S.PopupButtons>
+                    </S.PopupContentsContainer>
+                </S.PopupWrapper>
+            </Popup>
             <S.Header>
                 <Typography.Headline size="md">장소를 추가할</Typography.Headline>
                 <Typography.Headline size="md">여행 일정을 선택해주세요.</Typography.Headline>

--- a/src/pages/mytrip/PlaceAddPage/index.tsx
+++ b/src/pages/mytrip/PlaceAddPage/index.tsx
@@ -1,17 +1,21 @@
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
 
 import InfomationIcon from "../../../assets/icons/exclamation_circle.svg?react";
 import XIcon from "../../../assets/icons/x.svg?react";
 import PageHeader from "../../../components/common/PageHeader";
 import PageTemplate from "../../../components/common/PageTemplate";
 import Typography from "../../../components/common/Typography";
-
-import * as S from "./style";
-import { useEffect, useState } from "react";
 import LocationAddItem from "../../../components/mytrip/LocationAddItem";
-import { get, post } from "../../../utils/api";
+
+import { createTravelState } from "../../../recoil/mytrip/createTravelState";
 import usePopup from "../../../hooks/usePopup";
 import useAlert from "../../../hooks/useAlert";
+import { get, post } from "../../../utils/api";
+
+import * as S from "./style";
+
 
 export interface TMyTravelItem {
     "id": number,
@@ -37,6 +41,7 @@ const PlaceAddPage = () => {
         name: string,
     }>();
     const [currentSelectedItem, setCurrentSelectedItem] = useState<{id: number, day?: number}>({id: -1});
+    const setCreateTravelState = useSetRecoilState(createTravelState);
 
     const {Popup, popupOpen, popupClose} = usePopup();
     const {Alert, alertOpen, alertClose} = useAlert({
@@ -152,7 +157,10 @@ const PlaceAddPage = () => {
             </S.Header>
             <S.MyTravelHeader>
                 <Typography.Title size="lg">{data.length !== 0 && "나의 다가오는 여행"}</Typography.Title>
-                <S.CreateNewTravelButton onClick={() => {navigate('/mytrip/create')}}>
+                <S.CreateNewTravelButton onClick={() => {
+                    setCreateTravelState('add');
+                    navigate('/mytrip/create')
+                }}>
                     <Typography.Label size="lg" color="inherit">새로운 여행 일정 만들기</Typography.Label>
                 </S.CreateNewTravelButton>
             </S.MyTravelHeader>

--- a/src/pages/mytrip/PlaceAddPage/style.ts
+++ b/src/pages/mytrip/PlaceAddPage/style.ts
@@ -73,3 +73,66 @@ export const Button = styled.button<{isActive: boolean}>`
     justify-content: center;
     align-items: center;
 `
+
+export const PopupWrapper = styled.div`
+    width:100%;
+    height:100%;
+    max-width:500px;
+
+    margin-left:-20px;
+
+    position:fixed;
+    top:0;
+`
+
+export const PopupContentsContainer = styled.div`
+    width:100%;
+    padding:10px;
+
+    display:flex;
+    flex-direction:column;
+    justify-content:flex-start;
+    align-items:center;
+    gap:20px;
+
+    svg{
+        width:40px;
+        height:40px;
+    }
+`
+
+export const PopupTextContainer = styled.div`
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+
+    span:last-child{
+        margin-top:10px;
+    }
+`
+
+export const PopupButtons = styled.div`
+    width:100%;
+    
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    gap:12px;
+`
+
+export const PopupButton = styled.button<{isMain: boolean}>`
+    width:100%;
+    padding-top:12px;
+    padding-bottom:12px;
+
+    border:none;
+    border-radius:30px;
+
+    display:flex;
+    justify-content:center;
+    align-items:center;
+
+    background-color: ${({isMain, theme}) => isMain ? "#F3F6FF" : theme.gray06};
+    color: ${({isMain, theme}) => isMain ? theme.main : theme.black};
+    cursor:pointer;
+`

--- a/src/pages/mytrip/PlaceAddPage/style.ts
+++ b/src/pages/mytrip/PlaceAddPage/style.ts
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+
+export const Header = styled.div`
+    margin-top:15px;
+
+    display:flex;
+    flex-direction:column;
+`
+
+export const DeleteIcon = styled.div`
+    padding-top:15px;
+
+    svg{
+        width:28px;
+        height:28px;
+
+        path{
+            fill:black;
+        }
+    }
+`
+
+export const MyTravelList = styled.div`
+    width:100%;
+    margin-top:20px;
+
+    padding-left:20px;
+    padding-right:20px;
+
+    display:flex;
+    flex-direction:column;
+    justify-content:flex-start;
+    align-items:center;
+    gap:10px;
+`
+
+export const MyTravelHeader = styled.div`
+    margin-top:35px;
+    width:100%;
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+`
+
+export const CreateNewTravelButton = styled.div`
+    padding:4px 15px;
+    border: 1px solid ${({theme}) => theme.main};
+    border-radius:20px;
+
+    color:${({theme}) => theme.main};
+    cursor:pointer;
+`
+
+export const Footer = styled.footer`
+    width:100%;
+    padding: 15px 30px;
+
+    display:flex;
+    justify-content:center;
+    align-items:center;
+`
+
+export const Button = styled.button<{isActive: boolean}>`
+    width: 100%;
+    padding: 10px 20px 15px 20px;
+    border:none;
+    border-radius: 30px;
+
+    color:white;
+    background-color: ${({isActive, theme}) => isActive ? theme.main : "#A6A6A6"};
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`

--- a/src/recoil/mytrip/createTravelState.ts
+++ b/src/recoil/mytrip/createTravelState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const createTravelState = atom<'create' | 'edit' | 'add'>({
+    key: 'createTravelState',
+    default: 'create',
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -34,6 +34,7 @@ import FAQPage from "./pages/cscenter/FAQPage";
 import FAQDetailPage from "./pages/cscenter/FAQDetailPage";
 import InquiryPage from "./pages/cscenter/InquiryPage";
 import InquiryHistoryPage from "./pages/cscenter/InquiryHistoryPage";
+import PlaceAddPage from "./pages/mytrip/PlaceAddPage";
 
 const router = createBrowserRouter([
   {
@@ -69,6 +70,10 @@ const router = createBrowserRouter([
   {
     path: "/mytrip/create/location",
     element: <MyTripLocationSelectPage />,
+  },
+  {
+    path: "/mytrip/place/:id",
+    element: <PlaceAddPage />,
   },
   {
     path: "/mytrip/:id",


### PR DESCRIPTION
### 작업한 내용
관련 이슈: #89 
- 장소 페이지 UI 및 기능
- 단일 장소에 대한 스크랩 기능
- 단일 장소에 대한 여행 일정에 추가 기능

### 추후 해결해야 할 문제
- 백엔드에서 response가 불안정한 부분 발견 -> UI 테스트를 제대로 못함
- 여행 일정 생성 (캘린더) 페이지에 서로다른 세개의 접근 기능이 꼬여서 별도의 브랜치를 파서 해결할 예정 ( 전역상태를 만든 이유 )

### 중점적으로 봐 주었으면 하는 부분
- 알고 보니 저는 장소 추가할때 모달을 안쓰더라구요...? ㅋㅋㅋ 그래서 모달만 만드셔서 연결하시면 될것 같아요
- /mytrip/place/{place_id} 로 라우팅 하면, 해당 지역을 일정에 추가하는 페이지로 이동합니다!! 여기로 연결하시면 되요!
- 꼭 rebase안하고 저기로 navigate만 해놓으셔도 잘 동작하게 해놓겠습니당