### PR TITLE
Feature/#110 여행 일정 보기 디자인 변경 반영

### DIFF
--- a/src/components/common/PageTemplate/style.ts
+++ b/src/components/common/PageTemplate/style.ts
@@ -24,5 +24,6 @@ export const Content = styled.div<{ header: boolean }>`
   position: relative;
   width: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: ${({ header }) => (header ? "0 20px" : "40px 20px")};
 `;

--- a/src/components/tripDetail/DayPlan/index.tsx
+++ b/src/components/tripDetail/DayPlan/index.tsx
@@ -36,7 +36,9 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
         </S.EditButton>
       </S.DayInfo>
       <S.PlaceList>
-        {data.length !== 0 ? (
+        {data.length === 0 ? (
+          <AddPlaceButton />
+        ) : (
           <>
             {data.map((place, index) => (
               <S.PlaceItem>
@@ -51,10 +53,11 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
                 />
               </S.PlaceItem>
             ))}
-            <AddPlaceButton size="small" />
+            <S.PlaceItem>
+              <div></div>
+              <AddPlaceButton size="small" />
+            </S.PlaceItem>
           </>
-        ) : (
-          <AddPlaceButton />
         )}
       </S.PlaceList>
     </S.Container>

--- a/src/components/tripDetail/DayPlan/index.tsx
+++ b/src/components/tripDetail/DayPlan/index.tsx
@@ -1,50 +1,57 @@
 import * as S from "./style";
-import { useSetRecoilState } from "recoil";
-import TripPlanPlaceItem from "../TripPlanPlaceItem";
+import { parseDateString } from "../../../utils/parseDateString";
+import TripPlanPlaceItem, { PlaceData } from "../TripPlanPlaceItem";
 import AddPlaceButton from "../AddPlaceButton";
-
-import { planViewModeState } from "../../../recoil/planViewModeState";
-import { Place } from "../../../assets/data/tripPlanData";
-
 interface Props {
+  data: PlaceData[];
   day: number;
-  date: Date;
-  route: Place[];
+  date: string;
+  setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
-function DayPlan({ day, date, route }: Props) {
-  const setViewMode = useSetRecoilState(planViewModeState);
-  const dateToString = (date: Date) => {
-    const days = ["일", "월", "화", "수", "목", "금", "토"];
-    return `${date.getUTCMonth() + 1}.${date.getUTCDate()}/${
-      days[date.getUTCDay()]
-    }`;
-  };
+function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
+  const date = parseDateString(dateString);
+  const markerColors = [
+    "#5276FA",
+    "#FFAF37",
+    "#BA75FF",
+    "#FA5252",
+    "#30A9DE",
+    "#F29661",
+    "#78CBA2",
+  ];
 
   return (
     <S.Container>
       <S.DayInfo>
         <div>
           Day {day}
-          <span>{dateToString(date)}</span>
+          <span>{`${date?.month}. ${date?.day}(${date?.dayOfWeek})`}</span>
         </div>
         <S.EditButton
           onClick={() => {
-            setViewMode("EDIT");
+            setIsEditMode(true);
           }}
         >
           일정 편집
         </S.EditButton>
       </S.DayInfo>
       <S.PlaceList>
-        {route.length !== 0 ? (
+        {data.length !== 0 ? (
           <>
-            {route.map((place, index) => (
-              <TripPlanPlaceItem
-                place={place}
-                index={index}
-                addPlaceButton={index === route.length - 1 && true}
-              />
+            {data.map((place, index) => (
+              <S.PlaceItem>
+                <S.MarkerBox color={markerColors[day - (1 % 7)]}>
+                  <S.NumberSpan>{index + 1}</S.NumberSpan>
+                </S.MarkerBox>
+                <TripPlanPlaceItem
+                  {...place}
+                  day={day}
+                  index={index}
+                  setIsEditMode={setIsEditMode}
+                />
+              </S.PlaceItem>
             ))}
+            <AddPlaceButton size="small" />
           </>
         ) : (
           <AddPlaceButton />

--- a/src/components/tripDetail/DayPlan/index.tsx
+++ b/src/components/tripDetail/DayPlan/index.tsx
@@ -2,6 +2,7 @@ import * as S from "./style";
 import { DateObject, parseDateString } from "../../../utils/parseDateString";
 import TripPlanPlaceItem, { PlaceData } from "../TripPlanPlaceItem";
 import AddPlaceButton from "../AddPlaceButton";
+import { useNavigate } from "react-router-dom";
 interface Props {
   data: PlaceData[];
   day: number;
@@ -9,6 +10,7 @@ interface Props {
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
 function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
+  const navigate = useNavigate();
   const date = parseDateString(dateString);
   const markerColors = [
     "#5276FA",
@@ -19,6 +21,10 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
     "#F29661",
     "#78CBA2",
   ];
+
+  const clickAddPlaceButtonHandler = () => {
+    navigate(`./${day}/search`);
+  };
 
   return (
     <S.Container>
@@ -37,7 +43,7 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
       </S.DayInfo>
       <S.PlaceList>
         {data.length === 0 ? (
-          <AddPlaceButton />
+          <AddPlaceButton onClick={clickAddPlaceButtonHandler} />
         ) : (
           <>
             {data.map((place, index) => (
@@ -56,7 +62,10 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
             ))}
             <S.PlaceItem>
               <div></div>
-              <AddPlaceButton size="small" />
+              <AddPlaceButton
+                size="small"
+                onClick={clickAddPlaceButtonHandler}
+              />
             </S.PlaceItem>
           </>
         )}

--- a/src/components/tripDetail/DayPlan/index.tsx
+++ b/src/components/tripDetail/DayPlan/index.tsx
@@ -1,5 +1,5 @@
 import * as S from "./style";
-import { parseDateString } from "../../../utils/parseDateString";
+import { DateObject, parseDateString } from "../../../utils/parseDateString";
 import TripPlanPlaceItem, { PlaceData } from "../TripPlanPlaceItem";
 import AddPlaceButton from "../AddPlaceButton";
 interface Props {
@@ -48,6 +48,7 @@ function DayPlan({ data, day, date: dateString, setIsEditMode }: Props) {
                 <TripPlanPlaceItem
                   {...place}
                   day={day}
+                  date={date as DateObject}
                   index={index}
                   setIsEditMode={setIsEditMode}
                 />

--- a/src/components/tripDetail/DayPlan/style.ts
+++ b/src/components/tripDetail/DayPlan/style.ts
@@ -5,6 +5,13 @@ export const DayInfo = styled.p`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  & > div {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   margin-bottom: 20px;
   font-weight: 600;
   font-size: 14px;

--- a/src/components/tripDetail/DayPlan/style.ts
+++ b/src/components/tripDetail/DayPlan/style.ts
@@ -36,4 +36,37 @@ export const EditButton = styled.button`
     background-color: ${({ theme }) => theme.gray04};
   }
 `;
-export const PlaceList = styled.ol``;
+export const PlaceList = styled.ol`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const PlaceItem = styled.li`
+  display: grid;
+  grid-template-columns: 35px 1fr;
+  justify-items: center;
+  gap: 20px;
+`;
+
+export const MarkerBox = styled.div<{ color: string }>`
+  width: 18px;
+  height: 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+
+  background-color: ${({ color }) => color};
+  border-radius: 50%;
+  line-height: 0;
+`;
+export const NumberSpan = styled.span`
+  padding-top: 1px;
+  margin: auto;
+  line-height: 0;
+
+  font-weight: 500;
+  font-size: 11px;
+  color: ${({ theme }) => theme.white};
+`;

--- a/src/components/tripDetail/DayPlan/style.ts
+++ b/src/components/tripDetail/DayPlan/style.ts
@@ -39,7 +39,6 @@ export const EditButton = styled.button`
 export const PlaceList = styled.ol`
   display: flex;
   flex-direction: column;
-  gap: 20px;
 `;
 
 export const PlaceItem = styled.li`

--- a/src/components/tripDetail/DayPlanEdit/index.tsx
+++ b/src/components/tripDetail/DayPlanEdit/index.tsx
@@ -1,28 +1,35 @@
 import * as S from "./style";
 import { useEffect, useState } from "react";
-import { SetterOrUpdater } from "recoil";
 import { ItemInterface, ReactSortable } from "react-sortablejs";
-import { DayPlan, Place } from "../../../assets/data/tripPlanData";
 import EditablePlaceItem from "../EditablePlaceItem";
+import { PlaceData } from "../TripPlanPlaceItem";
+import { parseDateString } from "../../../utils/parseDateString";
 
 interface Props {
   day: number;
-  route: Place[];
-  setPlan: SetterOrUpdater<DayPlan[]>;
+  date: string;
+  route: PlaceData[];
 }
-type SortableRoute = ItemInterface & Place;
-function DayPlanEdit({ day, route: routeProp, setPlan }: Props) {
+type SortableRoute = ItemInterface & PlaceData;
+function DayPlanEdit({ day, date: dateString, route: routeProp }: Props) {
+  const date = parseDateString(dateString);
   const [route, setRoute] = useState<SortableRoute[]>([]);
 
   useEffect(() => {
     setRoute(
       routeProp.map((place) => ({ ...place, chosen: false, id: place.placeId }))
     );
-  }, [routeProp]);
+  }, []);
+  useEffect(() => {
+    console.dir(route);
+  }, [route]);
 
   return (
     <S.Container>
-      <S.DaySpan>Day {day}</S.DaySpan>
+      <S.DayParagraph>
+        Day {day}
+        <span>{`${date?.month}. ${date?.day}(${date?.dayOfWeek})`}</span>
+      </S.DayParagraph>
       <S.PlaceList>
         <ReactSortable
           group={"dayPlan"}

--- a/src/components/tripDetail/DayPlanEdit/style.ts
+++ b/src/components/tripDetail/DayPlanEdit/style.ts
@@ -1,14 +1,23 @@
 import styled from "styled-components";
 
 export const Container = styled.div``;
-export const DaySpan = styled.span`
-  display: block;
+export const DayParagraph = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+
+  color: ${({ theme }) => theme.black};
   font-weight: 600;
   font-size: 14px;
   line-height: 22px;
-  margin-bottom: 10px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.black};
+
+  span {
+    margin-left: 5px;
+    font-weight: 500;
+    color: ${({ theme }) => theme.gray01};
+    font-size: 13px;
+  }
 `;
 
 export const PlaceList = styled.ol`

--- a/src/components/tripDetail/EditablePlaceItem/index.tsx
+++ b/src/components/tripDetail/EditablePlaceItem/index.tsx
@@ -3,11 +3,10 @@ import { useState } from "react";
 import SelectIcon from "../../../assets/icons/select.svg?react";
 import SelectFilledIcon from "../../../assets/icons/select_filled.svg?react";
 import HamburgerIcon from "../../../assets/icons/hamburger.svg?react";
-
-import { Place } from "../../../assets/data/tripPlanData";
+import { PlaceData } from "../TripPlanPlaceItem";
 
 interface Props {
-  place: Place;
+  place: PlaceData;
   index: number;
 }
 function EditablePlaceItem({ place, index }: Props) {
@@ -54,10 +53,10 @@ function EditablePlaceItem({ place, index }: Props) {
       >
         {isSelected ? <SelectFilledIcon /> : <SelectIcon />}
         <S.PlaceInfo>
-          <span>{index + 1}</span>
+          {/* <span>{index + 1}</span> */}
           <div>
             <p>{place.placeName}</p>
-            <p>{place.theme}</p>
+            <p>{place.placeTheme}</p>
           </div>
         </S.PlaceInfo>
         <HamburgerIcon className="handle" />

--- a/src/components/tripDetail/EditablePlaceItem/style.ts
+++ b/src/components/tripDetail/EditablePlaceItem/style.ts
@@ -39,14 +39,18 @@ export const Wrapper = styled.div<{ isSelected: boolean; translateX: number }>`
   cursor: pointer;
   background-color: ${({ theme, isSelected }) =>
     isSelected ? theme.blue04 : theme.white};
+
+  svg {
+    path {
+      fill: ${({ theme }) => theme.blue02};
+    }
+  }
 `;
+
 export const PlaceInfo = styled.div`
   flex-grow: 1;
   padding: 10px 16px;
   display: flex;
-
-  font-size: 14px;
-  font-weight: 500;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.blue05};
 
@@ -62,11 +66,18 @@ export const PlaceInfo = styled.div`
     line-height: 22px;
     border-radius: 50%;
     color: ${({ theme }) => theme.white};
-    background-color: ${({ theme }) => theme.blue03};
+    background-color: ${({ theme }) => theme.main};
   }
 
   & > div {
     color: ${({ theme }) => theme.black};
+
+    p {
+      font-weight: 600;
+      line-height: 22px; /* 157.143% */
+      font-size: 14px;
+      font-weight: 500;
+    }
 
     p:last-of-type {
       font-size: 11px;

--- a/src/components/tripDetail/PlanMap/index.tsx
+++ b/src/components/tripDetail/PlanMap/index.tsx
@@ -7,13 +7,15 @@ import GoogleMap from "../../common/GoogleMap";
 import ChevronBottomIcon from "../../../assets/icons/chevron_bottom.svg?react";
 import ChevronTopIcon from "../../../assets/icons/chevron_top.svg?react";
 
-import { planViewModeState } from "../../../recoil/planViewModeState";
 import { tripPlanState } from "../../../recoil/tripState";
 
-function PlanMap() {
+interface Props {
+  isEditMode: boolean;
+}
+
+function PlanMap({ isEditMode }: Props) {
   const [markers, setMarkers] = useState<MarkerProps[]>([]);
   const [mapOpened, setMapOpend] = useState<boolean>(true);
-  const viewMode = useRecoilValue(planViewModeState);
   const plan = useRecoilValue(tripPlanState);
   const findMidLatLng = () => {
     const result = {
@@ -45,14 +47,9 @@ function PlanMap() {
   };
 
   useEffect(() => {
-    if (viewMode === "EDIT") {
+    if (isEditMode) {
       setMapOpend(false);
-    } else {
-      setMapOpend(true);
     }
-  }, [viewMode]);
-
-  useEffect(() => {
     plan?.map(({ route }) => {
       route?.map(({ placeName, position }) => {
         setMarkers((prev) => [

--- a/src/components/tripDetail/PlanMap/index.tsx
+++ b/src/components/tripDetail/PlanMap/index.tsx
@@ -47,9 +47,6 @@ function PlanMap({ isEditMode }: Props) {
   };
 
   useEffect(() => {
-    if (isEditMode) {
-      setMapOpend(false);
-    }
     plan?.map(({ route }) => {
       route?.map(({ placeName, position }) => {
         setMarkers((prev) => [
@@ -62,6 +59,13 @@ function PlanMap({ isEditMode }: Props) {
       });
     });
   }, []);
+  useEffect(() => {
+    if (isEditMode) {
+      setMapOpend(false);
+    } else {
+      setMapOpend(true);
+    }
+  }, [isEditMode]);
 
   return (
     <S.Container>

--- a/src/components/tripDetail/PlanMap/style.ts
+++ b/src/components/tripDetail/PlanMap/style.ts
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  width: calc(100% + 40px);
+  transform: translateX(-20px);
+`;
 export const MapOpenButton = styled.button`
   display: block;
   border: 0;

--- a/src/components/tripDetail/TripPlanList/index.tsx
+++ b/src/components/tripDetail/TripPlanList/index.tsx
@@ -1,44 +1,57 @@
 import * as S from "./style";
-import { useRecoilState } from "recoil";
 import DayPlan from "../DayPlan";
 import DayPlanEdit from "../DayPlanEdit";
 import ArrowBottomIcon from "../../../assets/icons/arrow_bottom.svg?react";
-import { planViewModeState } from "../../../recoil/planViewModeState";
-import { tripPlanState } from "../../../recoil/tripState";
+import { TripData } from "../../../pages/mytrip/DetailPage";
+import { PlaceData } from "../TripPlanPlaceItem";
 
-function TripPlanList() {
-  const [viewMode, setViewMode] = useRecoilState(planViewModeState);
-  const [plan, setPlan] = useRecoilState(tripPlanState);
+export interface DayPlan {
+  day: number;
+  date: string;
+  dayOfWeek: "일" | "월" | "화" | "수" | "목" | "금" | "토";
+  route: PlaceData[];
+}
 
+interface Props {
+  data: TripData;
+  isEditMode: boolean;
+  setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+function TripPlanList({ data, isEditMode, setIsEditMode }: Props) {
   return (
     <S.Container>
-      <S.DayFilterButton onClick={() => {}}>
-        전체 일정
-        <ArrowBottomIcon />
-      </S.DayFilterButton>
+      {data.plan.length >= 0 && (
+        <S.DayFilterButton onClick={() => {}}>
+          전체 일정
+          <ArrowBottomIcon />
+        </S.DayFilterButton>
+      )}
       <S.PlaceListContainer>
-        {viewMode === "EDIT" && (
+        {isEditMode && (
           <S.EditComplateButton
             onClick={() => {
-              setViewMode("PLAN");
+              setIsEditMode(false);
             }}
           >
             완료
           </S.EditComplateButton>
         )}
-        {viewMode === "EDIT"
-          ? plan?.map((dayPlan) => (
-              <DayPlanEdit
-                day={dayPlan.day}
-                route={dayPlan.route}
-                setPlan={setPlan}
-              />
+        {isEditMode
+          ? data.plan.map((dayPlan) => (
+              // <DayPlanEdit
+              //   day={dayPlan.day}
+              //   route={dayPlan.route}
+              //   setPlan={setPlan}
+              // />
+              <></>
             ))
-          : plan?.map((dayPlan) => (
+          : data.plan.map((dayPlan) => (
               <DayPlan
                 day={dayPlan.day}
                 date={dayPlan.date}
-                route={dayPlan.route}
+                data={dayPlan.route}
+                setIsEditMode={setIsEditMode}
               />
             ))}
       </S.PlaceListContainer>

--- a/src/components/tripDetail/TripPlanList/index.tsx
+++ b/src/components/tripDetail/TripPlanList/index.tsx
@@ -39,12 +39,11 @@ function TripPlanList({ data, isEditMode, setIsEditMode }: Props) {
         )}
         {isEditMode
           ? data.plan.map((dayPlan) => (
-              // <DayPlanEdit
-              //   day={dayPlan.day}
-              //   route={dayPlan.route}
-              //   setPlan={setPlan}
-              // />
-              <></>
+              <DayPlanEdit
+                day={dayPlan.day}
+                date={dayPlan.date}
+                route={dayPlan.route}
+              />
             ))
           : data.plan.map((dayPlan) => (
               <DayPlan

--- a/src/components/tripDetail/TripPlanList/style.ts
+++ b/src/components/tripDetail/TripPlanList/style.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
+  padding-bottom: 30px;
   width: 100%;
   background-color: ${({ theme }) => theme.white};
 `;

--- a/src/components/tripDetail/TripPlanList/style.ts
+++ b/src/components/tripDetail/TripPlanList/style.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   width: 100%;
+  background-color: ${({ theme }) => theme.white};
 `;
 export const DayFilterButton = styled.button`
   margin-bottom: 10px;
@@ -9,13 +10,14 @@ export const DayFilterButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  cursor: pointer;
   border-radius: 8px;
   border: 0;
   background-color: transparent;
   font-size: 13px;
   line-height: 22px;
   font-weight: 700;
-  cursor: pointer;
 
   &:hover {
     background-color: ${({ theme }) => theme.gray05};

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -12,6 +12,7 @@ export interface PlaceData {
   placeName: string;
   placeTheme: string;
   placeId: number;
+  location: string;
   googlePlaceId: string;
   placeImage: string;
   latitude: number;
@@ -34,13 +35,13 @@ function TripPlanPlaceItem({
   memo,
   day,
   date,
+  location,
   index,
   setIsEditMode,
 }: Props) {
   const navigate = useNavigate();
   const onLongClick = useLongPress(
     () => {
-      console.log("longClick");
       setIsEditMode(true);
     },
     {
@@ -63,9 +64,8 @@ function TripPlanPlaceItem({
           </Typography.Title>
           <S.InfoContainer>
             <S.InfoSpan>
-              {/* @todo: API에 지역 없음 */}
               <LocationIcon />
-              지역
+              {location}
             </S.InfoSpan>
             <S.InfoSpan>
               <ThemeIcon />

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -4,7 +4,8 @@ import ThemeIcon from "../../../assets/icons/theme.svg?react";
 import LocationIcon from "../../../assets/icons/location.svg?react";
 import EditIcon from "../../../assets/icons/edit.svg?react";
 import Typography from "../../common/Typography";
-import { useNavigate } from "react-router-dom";
+import { createSearchParams, useNavigate } from "react-router-dom";
+import { DateObject } from "../../../utils/parseDateString";
 
 export interface PlaceData {
   detailRouteId: number;
@@ -20,6 +21,7 @@ export interface PlaceData {
 
 interface Props extends PlaceData {
   day: number;
+  date: DateObject;
   index: number;
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -31,6 +33,7 @@ function TripPlanPlaceItem({
   placeId,
   memo,
   day,
+  date,
   index,
   setIsEditMode,
 }: Props) {
@@ -75,6 +78,16 @@ function TripPlanPlaceItem({
         <S.MemoButton
           onClick={(e) => {
             e.stopPropagation();
+            navigate({
+              pathname: `./memo`,
+              search: createSearchParams({
+                detailRouteId: String(detailRouteId),
+                day: String(day),
+                placeName: placeName,
+                date: `${date.month}. ${date.day}(${date.dayOfWeek})`,
+                text: memo,
+              }).toString(),
+            });
           }}
         >
           메모하기

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -38,8 +38,6 @@ function TripPlanPlaceItem({
   setIsEditMode,
 }: Props) {
   const navigate = useNavigate();
-  memo =
-    "Lorem Ipsum is simply dummy text of the printing and type set ti asd ng setting industry.. ";
   const onLongClick = useLongPress(
     () => {
       console.log("longClick");
@@ -85,7 +83,7 @@ function TripPlanPlaceItem({
                 day: String(day),
                 placeName: placeName,
                 date: `${date.month}. ${date.day}(${date.dayOfWeek})`,
-                text: memo,
+                text: memo || "",
               }).toString(),
             });
           }}

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -4,6 +4,7 @@ import ThemeIcon from "../../../assets/icons/theme.svg?react";
 import LocationIcon from "../../../assets/icons/location.svg?react";
 import EditIcon from "../../../assets/icons/edit.svg?react";
 import Typography from "../../common/Typography";
+import { useNavigate } from "react-router-dom";
 
 export interface PlaceData {
   detailRouteId: number;
@@ -28,15 +29,12 @@ function TripPlanPlaceItem({
   placeName,
   placeTheme,
   placeId,
-  googlePlaceId,
-  placeImage,
-  latitude,
-  longitude,
   memo,
   day,
   index,
   setIsEditMode,
 }: Props) {
+  const navigate = useNavigate();
   memo =
     "Lorem Ipsum is simply dummy text of the printing and type set ti asd ng setting industry.. ";
   const onLongClick = useLongPress(
@@ -45,7 +43,7 @@ function TripPlanPlaceItem({
       setIsEditMode(true);
     },
     {
-      threshold: 500, // ms
+      threshold: 600, // ms
       captureEvent: true, // 첫번째 인자로 들어온 callback 함수가 react MouseEvent를 도와주게 설정
       cancelOnMovement: false, // 꾹 눌렀다가 옆으로 이동했을때 취소
     }
@@ -54,7 +52,11 @@ function TripPlanPlaceItem({
   return (
     <S.PlaceBox {...onLongClick()}>
       <S.TitleBox>
-        <div>
+        <div
+          onClick={() => {
+            navigate(`/place/${placeId}`);
+          }}
+        >
           <Typography.Title size="md" noOfLine={3}>
             {placeName}
           </Typography.Title>

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -1,5 +1,9 @@
 import * as S from "./style";
 import { useLongPress } from "use-long-press";
+import ThemeIcon from "../../../assets/icons/theme.svg?react";
+import LocationIcon from "../../../assets/icons/location.svg?react";
+import EditIcon from "../../../assets/icons/edit.svg?react";
+import Typography from "../../common/Typography";
 
 export interface PlaceData {
   detailRouteId: number;
@@ -33,7 +37,8 @@ function TripPlanPlaceItem({
   index,
   setIsEditMode,
 }: Props) {
-  const hasMemo = memo !== "";
+  memo =
+    "Lorem Ipsum is simply dummy text of the printing and type set ti asd ng setting industry.. ";
   const onLongClick = useLongPress(
     () => {
       console.log("longClick");
@@ -47,17 +52,35 @@ function TripPlanPlaceItem({
   );
 
   return (
-    // <S.PlaceItem >
     <S.PlaceBox {...onLongClick()}>
-      <S.PlaceTextBox hasMemo={hasMemo}>
+      <S.TitleBox>
         <div>
-          <S.PlaceNameParagraph>{placeName}</S.PlaceNameParagraph>
-          <S.PlaceThemeParagraph>{placeTheme}</S.PlaceThemeParagraph>
+          <Typography.Title size="md" noOfLine={3}>
+            {placeName}
+          </Typography.Title>
+          <S.InfoContainer>
+            <S.InfoSpan>
+              {/* @todo: API에 지역 없음 */}
+              <LocationIcon />
+              지역
+            </S.InfoSpan>
+            <S.InfoSpan>
+              <ThemeIcon />
+              {placeTheme}
+            </S.InfoSpan>
+          </S.InfoContainer>
         </div>
-        {hasMemo && <S.PlaceMemoParagraph>{memo}</S.PlaceMemoParagraph>}
-      </S.PlaceTextBox>
+        <S.MemoButton
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          메모하기
+          <EditIcon />
+        </S.MemoButton>
+      </S.TitleBox>
+      {memo && memo.length >= 0 && <S.MemoParagraph>{memo}</S.MemoParagraph>}
     </S.PlaceBox>
-    // </S.PlaceItem>
   );
 }
 

--- a/src/components/tripDetail/TripPlanPlaceItem/index.tsx
+++ b/src/components/tripDetail/TripPlanPlaceItem/index.tsx
@@ -1,67 +1,63 @@
 import * as S from "./style";
 import { useLongPress } from "use-long-press";
-import { useSetRecoilState } from "recoil";
-import AddPlaceButton from "../AddPlaceButton";
-import imagePlaceholder from "../../../assets/icons/image_placeholder_circle.svg";
-import CarIcon from "../../../assets/icons/car.svg?react";
-import SubwayIcon from "../../../assets/icons/subway.svg?react";
-import WalkIcon from "../../../assets/icons/walk.svg?react";
-import { planViewModeState } from "../../../recoil/planViewModeState";
-import { Place } from "../../../assets/data/tripPlanData";
 
-interface Props {
-  place: Place;
-  index: number;
-  addPlaceButton?: boolean;
+export interface PlaceData {
+  detailRouteId: number;
+  placeName: string;
+  placeTheme: string;
+  placeId: number;
+  googlePlaceId: string;
+  placeImage: string;
+  latitude: number;
+  longitude: number;
+  memo: string;
 }
-function TripPlanPlaceItem({ place, index, addPlaceButton = false }: Props) {
-  const setViewMode = useSetRecoilState(planViewModeState);
-  const hasMemo = place.memo !== "";
-  const transportIconMap = {
-    도보: <WalkIcon />,
-    지하철: <SubwayIcon />,
-    버스: <SubwayIcon />,
-    대중교통: <SubwayIcon />,
-    차량: <CarIcon />,
-  };
-  const onLongClick = useLongPress(() => {
-    setViewMode("EDIT");
-  });
+
+interface Props extends PlaceData {
+  day: number;
+  index: number;
+  setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+function TripPlanPlaceItem({
+  detailRouteId,
+  placeName,
+  placeTheme,
+  placeId,
+  googlePlaceId,
+  placeImage,
+  latitude,
+  longitude,
+  memo,
+  day,
+  index,
+  setIsEditMode,
+}: Props) {
+  const hasMemo = memo !== "";
+  const onLongClick = useLongPress(
+    () => {
+      console.log("longClick");
+      setIsEditMode(true);
+    },
+    {
+      threshold: 500, // ms
+      captureEvent: true, // 첫번째 인자로 들어온 callback 함수가 react MouseEvent를 도와주게 설정
+      cancelOnMovement: false, // 꾹 눌렀다가 옆으로 이동했을때 취소
+    }
+  );
 
   return (
-    <S.PlaceItem>
-      <S.MarkerBox>
-        <S.NumberSpan>{index + 1}</S.NumberSpan>
-        <S.TransportBox>
-          {place.transport && place.travelTime && (
-            <p>
-              <span>{place.transport}</span>
-              {transportIconMap[place.transport]}
-              <span>{place.travelTime}</span>
-            </p>
-          )}
-        </S.TransportBox>
-      </S.MarkerBox>
-      <S.PlaceBox {...onLongClick()}>
-        <S.PlaceTextBox hasMemo={hasMemo}>
-          <div>
-            <S.PlaceNameParagraph>{place.placeName}</S.PlaceNameParagraph>
-            <S.PlaceThemeParagraph>{place.theme}</S.PlaceThemeParagraph>
-          </div>
-          {hasMemo && <S.PlaceMemoParagraph>{place.memo}</S.PlaceMemoParagraph>}
-        </S.PlaceTextBox>
-        <img
-          src={place.placeImage ? place.placeImage : imagePlaceholder}
-          alt=""
-        />
-      </S.PlaceBox>
-      {addPlaceButton && (
-        <>
-          <span></span>
-          <AddPlaceButton size="small" />
-        </>
-      )}
-    </S.PlaceItem>
+    // <S.PlaceItem >
+    <S.PlaceBox {...onLongClick()}>
+      <S.PlaceTextBox hasMemo={hasMemo}>
+        <div>
+          <S.PlaceNameParagraph>{placeName}</S.PlaceNameParagraph>
+          <S.PlaceThemeParagraph>{placeTheme}</S.PlaceThemeParagraph>
+        </div>
+        {hasMemo && <S.PlaceMemoParagraph>{memo}</S.PlaceMemoParagraph>}
+      </S.PlaceTextBox>
+    </S.PlaceBox>
+    // </S.PlaceItem>
   );
 }
 

--- a/src/components/tripDetail/TripPlanPlaceItem/style.ts
+++ b/src/components/tripDetail/TripPlanPlaceItem/style.ts
@@ -1,91 +1,17 @@
-import styled, { css } from "styled-components";
-import line from "../../../assets/icons/line.svg";
+import styled from "styled-components";
 
-// const lineCss = css`
-//   content: "";
-//   flex-grow: 2;
-//   display: block;
-//   width: 1.6px;
-//   background-image: url(${line});
-//   background-repeat: repeat-y;
-//   background-size: unset;
-// `;
-
-// export const PlaceItem = styled.li`
-//   width: 100%;
-//   display: grid;
-//   grid-template-columns: min-content 1fr;
-//   align-items: center;
-//   gap: 10px;
-
-//   &:not(:last-of-type) {
-//     padding-bottom: 10px;
-
-//     // 숫자마커 위, 아래 라인
-//     & > div:first-of-type > div {
-//       &::before,
-//       &::after {
-//         ${lineCss}
-//       }
-//     }
-//   }
-// `;
-
-// export const MarkerBox = styled.div<{ color: string }>`
-//   width: 18px;
-//   height: 18px;
-//   display: flex;
-//   flex-direction: column;
-//   align-items: center;
-//   gap: 8px;
-
-//   background-color: ${({ color }) => color};
-//   border-radius: 50%;
-//   line-height: 0;
-// `;
-// export const NumberSpan = styled.span`
-//   margin: auto;
-//   line-height: 0;
-
-//   font-weight: 500;
-//   font-size: 11px;
-//   color: ${({ theme }) => theme.white};
-// `;
-
-export const TransportBox = styled.div`
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-
-  font-size: 10px;
-  font-weight: 500;
-  text-align: center;
-  color: ${({ theme }) => theme.gray02};
-  word-break: keep-all;
-
-  p {
-    margin: 3px 0;
-    // 스크린리더 지원 텍스트
-    span:first-of-type {
-      visibility: hidden;
-      position: absolute;
-    }
-    svg {
-      margin-bottom: 2px;
-    }
-  }
-`;
 export const PlaceBox = styled.div`
   width: 100%;
-  padding: 12px 20px;
-  margin-bottom: 20px;
   height: fit-content;
-  display: grid;
-  grid-template-columns: 1fr 38px;
-  gap: 10px;
-  align-items: center;
+  margin-bottom: 20px;
+  padding: 12px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  cursor: pointer;
+  text-align: left;
+  border: 0;
   background-color: ${({ theme }) => theme.blue05};
   border-radius: 10px;
 
@@ -94,31 +20,78 @@ export const PlaceBox = styled.div`
     height: 38px;
     border-radius: 50%;
   }
-`;
 
-export const PlaceTextBox = styled.div<{ hasMemo: boolean }>`
-  word-break: keep-all;
-
-  div {
-    display: flex;
-    flex-direction: ${({ hasMemo }) => (hasMemo ? "row" : "column")};
-    align-items: ${({ hasMemo }) => (hasMemo ? "flex-end" : "flex-start")};
-    gap: ${({ hasMemo }) => (hasMemo ? "7px" : "0")};
+  &:active {
+    outline: 3px solid ${({ theme }) => theme.blue04};
+    box-shadow: 0 5px 10px #849fff70;
   }
 `;
-export const PlaceNameParagraph = styled.p`
-  line-height: 22px;
-  font-weight: 600;
-  font-size: 14px;
-  color: ${({ theme }) => theme.black};
+
+export const TitleBox = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  word-break: keep-all;
 `;
-export const PlaceThemeParagraph = styled.p`
+
+export const MemoButton = styled.button`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+
+  cursor: pointer;
+  font-size: 12px;
+  border: 1px solid ${({ theme }) => theme.blue04};
+  border-radius: 8px;
+
+  color: ${({ theme }) => theme.main};
+  background-color: transparent;
+  transition: all 0.3s ease-in-out;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.blue04};
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    path {
+      fill: ${({ theme }) => theme.main};
+    }
+  }
+`;
+export const InfoContainer = styled.div`
+  margin-top: 5px;
+  display: flex;
+  gap: 7px;
+`;
+
+export const InfoSpan = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+
+  color: ${({ theme }) => theme.gray02};
   font-size: 11px;
-  line-height: 18px;
+  font-style: normal;
   font-weight: 400;
-  color: ${({ theme }) => theme.gray01};
+  line-height: 16px; /* 145.455% */
+  letter-spacing: 0.5px;
+
+  svg {
+    width: 16px;
+    height: 16px;
+
+    path {
+      fill: ${({ theme }) => theme.gray02};
+    }
+  }
 `;
-export const PlaceMemoParagraph = styled.p`
+export const MemoParagraph = styled.p`
+  padding: 8px 0 10px;
   font-size: 11px;
   line-height: 18px;
   font-weight: 400;

--- a/src/components/tripDetail/TripPlanPlaceItem/style.ts
+++ b/src/components/tripDetail/TripPlanPlaceItem/style.ts
@@ -1,59 +1,57 @@
 import styled, { css } from "styled-components";
 import line from "../../../assets/icons/line.svg";
 
-const lineCss = css`
-  content: "";
-  flex-grow: 2;
-  display: block;
-  width: 1.6px;
-  background-image: url(${line});
-  background-repeat: repeat-y;
-  background-size: unset;
-`;
+// const lineCss = css`
+//   content: "";
+//   flex-grow: 2;
+//   display: block;
+//   width: 1.6px;
+//   background-image: url(${line});
+//   background-repeat: repeat-y;
+//   background-size: unset;
+// `;
 
-export const PlaceItem = styled.li`
-  width: 100%;
-  display: grid;
-  grid-template-columns: min-content 1fr;
-  align-items: center;
-  gap: 10px;
+// export const PlaceItem = styled.li`
+//   width: 100%;
+//   display: grid;
+//   grid-template-columns: min-content 1fr;
+//   align-items: center;
+//   gap: 10px;
 
-  &:not(:last-of-type) {
-    padding-bottom: 10px;
+//   &:not(:last-of-type) {
+//     padding-bottom: 10px;
 
-    // 숫자마커 위, 아래 라인
-    & > div:first-of-type > div {
-      &::before,
-      &::after {
-        ${lineCss}
-      }
-    }
-  }
-`;
+//     // 숫자마커 위, 아래 라인
+//     & > div:first-of-type > div {
+//       &::before,
+//       &::after {
+//         ${lineCss}
+//       }
+//     }
+//   }
+// `;
 
-export const MarkerBox = styled.div`
-  display: grid;
-  grid-template-rows: fit-content(100%) 1fr;
-  height: 100%;
-  gap: 8px;
-  flex-direction: column;
-  align-items: center;
-`;
-export const NumberSpan = styled.span`
-  display: flex;
-  margin: auto;
-  align-items: center;
-  justify-content: center;
-  padding-top: 2px;
-  width: 18px;
-  height: 18px;
+// export const MarkerBox = styled.div<{ color: string }>`
+//   width: 18px;
+//   height: 18px;
+//   display: flex;
+//   flex-direction: column;
+//   align-items: center;
+//   gap: 8px;
 
-  font-weight: 500;
-  font-size: 11px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.main};
-  color: ${({ theme }) => theme.white};
-`;
+//   background-color: ${({ color }) => color};
+//   border-radius: 50%;
+//   line-height: 0;
+// `;
+// export const NumberSpan = styled.span`
+//   margin: auto;
+//   line-height: 0;
+
+//   font-weight: 500;
+//   font-size: 11px;
+//   color: ${({ theme }) => theme.white};
+// `;
+
 export const TransportBox = styled.div`
   height: 100%;
   display: flex;
@@ -80,6 +78,7 @@ export const TransportBox = styled.div`
   }
 `;
 export const PlaceBox = styled.div`
+  width: 100%;
   padding: 12px 20px;
   height: fit-content;
   display: grid;

--- a/src/components/tripDetail/TripPlanPlaceItem/style.ts
+++ b/src/components/tripDetail/TripPlanPlaceItem/style.ts
@@ -80,6 +80,7 @@ export const TransportBox = styled.div`
 export const PlaceBox = styled.div`
   width: 100%;
   padding: 12px 20px;
+  margin-bottom: 20px;
   height: fit-content;
   display: grid;
   grid-template-columns: 1fr 38px;

--- a/src/pages/mytrip/DetailPage/index.tsx
+++ b/src/pages/mytrip/DetailPage/index.tsx
@@ -1,5 +1,5 @@
 import * as S from "./style";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 
 import PageTemplate from "../../../components/common/PageTemplate";
@@ -8,27 +8,59 @@ import TripPlanListPlaceHolder from "../../../components/tripDetail/TripPlanList
 import TripPlanList from "../../../components/tripDetail/TripPlanList";
 import PlanMap from "../../../components/tripDetail/PlanMap";
 import EditModeBottomControlBox from "../../../components/tripDetail/EditModeBottomControlBox";
-import ClapBlueIcon from "../../../assets/icons/clap_blue.svg?react";
 
 import { tripPlanState } from "../../../recoil/tripState";
 import { planViewModeState } from "../../../recoil/planViewModeState";
+import { useLoaderData, useParams } from "react-router-dom";
+import Typography from "../../../components/common/Typography";
+import { get } from "../../../utils/api";
+
+interface PlaceData {
+  detailRouteId: number;
+  placeName: string;
+  placeTheme: string;
+  placeId: number;
+  googlePlaceId: string;
+  placeImage: string;
+  latitude: number;
+  longitude: number;
+  memo: string;
+}
+
+interface DayPlan {
+  day: number;
+  date: string;
+  dayOfWeek: "일" | "월" | "화" | "수" | "목" | "금" | "토";
+  route: PlaceData[];
+}
+
+interface TripData {
+  id: number;
+  title: string;
+  departure_date: string;
+  arrival_date: string;
+  days: number;
+  location: string[];
+  plan: DayPlan[];
+}
 
 function MyTripDetailPage() {
   // @todo: id를 통해 일정 데이터 비동기 요청 불러와 State로 관리하기
-  // const { id } = useParams(); // 파라미터에 게시글 ID
+  const { id } = useParams(); // 파라미터에 게시글 ID
+  const nickname = useLoaderData() as string;
   const [viewMode, setViewMode] = useRecoilState(planViewModeState);
   const tripPlan = useRecoilValue(tripPlanState);
+  const [data, setData] = useState<TripData | null>(null);
 
-  // @todo: 사용자 정보 state로 관리
-  const username = "최민석";
+  const getData = async (id: number) => {
+    const { data } = await get<TripData>(`/my-travel/${id}`);
+    console.dir(data);
+    setData(data);
+  };
 
   useEffect(() => {
-    console.log(tripPlan);
-    if (tripPlan?.length !== 0) {
-      setViewMode("PLAN");
-    } else {
-      setViewMode("NOPLAN");
-    }
+    getData(Number(id));
+    setViewMode("NOPLAN");
   }, [tripPlan]);
 
   return (
@@ -39,11 +71,10 @@ function MyTripDetailPage() {
       {viewMode === "NOPLAN" ? (
         <>
           <S.MessageBox>
-            <p>
-              {username}님, 새로운 여행 일정이 만들어졌어요!
-              <ClapBlueIcon />
-            </p>
-            <p>아래에 장소를 추가해 계획을 완성해보세요:)</p>
+            <Typography.Body size="md" color="#5276FA">
+              <p>{nickname}님, 새로운 여행 일정이 만들어졌어요!</p>
+              <p>아래 장소 추가 버튼을 통해 계획을 세워가보세요. 🙂</p>
+            </Typography.Body>
           </S.MessageBox>
           <TripPlanListPlaceHolder days={4} />
         </>

--- a/src/pages/mytrip/DetailPage/index.tsx
+++ b/src/pages/mytrip/DetailPage/index.tsx
@@ -1,40 +1,19 @@
 import * as S from "./style";
 import { useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
 import { useLoaderData, useParams } from "react-router-dom";
-
 import { get } from "../../../utils/api";
 import { parseDateString, DateObject } from "../../../utils/parseDateString";
-import { tripPlanState } from "../../../recoil/tripState";
-import { planViewModeState } from "../../../recoil/planViewModeState";
 
 import PageTemplate from "../../../components/common/PageTemplate";
-import TripPlanList from "../../../components/tripDetail/TripPlanList";
+import TripPlanList, {
+  DayPlan,
+} from "../../../components/tripDetail/TripPlanList";
 import PlanMap from "../../../components/tripDetail/PlanMap";
 import EditModeBottomControlBox from "../../../components/tripDetail/EditModeBottomControlBox";
 import Typography from "../../../components/common/Typography";
 import CalendarIcon from "../../../assets/icons/calendar.svg?react";
 
-interface PlaceData {
-  detailRouteId: number;
-  placeName: string;
-  placeTheme: string;
-  placeId: number;
-  googlePlaceId: string;
-  placeImage: string;
-  latitude: number;
-  longitude: number;
-  memo: string;
-}
-
-interface DayPlan {
-  day: number;
-  date: string;
-  dayOfWeek: "일" | "월" | "화" | "수" | "목" | "금" | "토";
-  route: PlaceData[];
-}
-
-interface TripData {
+export interface TripData {
   id: number;
   title: string;
   departure_date: string;
@@ -47,10 +26,7 @@ interface TripData {
 function MyTripDetailPage() {
   const { id } = useParams(); // 파라미터에 게시글 ID
   const nickname = useLoaderData() as string;
-
-  const [viewMode, setViewMode] = useRecoilState(planViewModeState);
-  const tripPlan = useRecoilValue(tripPlanState);
-
+  const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const [data, setData] = useState<TripData>({
     id: -1,
     title: "",
@@ -123,12 +99,11 @@ function MyTripDetailPage() {
 
   useEffect(() => {
     getData(Number(id));
-    setViewMode("NOPLAN");
   }, []);
 
   return (
     <PageTemplate
-      nav={viewMode === "EDIT" ? <EditModeBottomControlBox /> : "default"}
+      nav={isEditMode ? <EditModeBottomControlBox /> : "default"}
       header={
         <S.Header>
           <Typography.Headline size="md">{data.title}</Typography.Headline>
@@ -141,8 +116,7 @@ function MyTripDetailPage() {
         </S.Header>
       }
     >
-      {false ? (
-        // {data.plan.length > 0 ? (
+      {data.plan.length > 0 ? (
         <PlanMap />
       ) : (
         <S.MessageBox>
@@ -152,7 +126,11 @@ function MyTripDetailPage() {
           </Typography.Body>
         </S.MessageBox>
       )}
-      <TripPlanList />
+      <TripPlanList
+        data={data}
+        isEditMode={isEditMode}
+        setIsEditMode={setIsEditMode}
+      />
     </PageTemplate>
   );
 }

--- a/src/pages/mytrip/DetailPage/index.tsx
+++ b/src/pages/mytrip/DetailPage/index.tsx
@@ -117,7 +117,7 @@ function MyTripDetailPage() {
       }
     >
       {data.plan.length > 0 ? (
-        <PlanMap />
+        <PlanMap isEditMode={isEditMode} />
       ) : (
         <S.MessageBox>
           <Typography.Body size="md" color="#5276FA">

--- a/src/pages/mytrip/DetailPage/index.tsx
+++ b/src/pages/mytrip/DetailPage/index.tsx
@@ -1,19 +1,19 @@
 import * as S from "./style";
 import { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
+import { useLoaderData, useParams } from "react-router-dom";
+
+import { get } from "../../../utils/api";
+import { parseDateString, DateObject } from "../../../utils/parseDateString";
+import { tripPlanState } from "../../../recoil/tripState";
+import { planViewModeState } from "../../../recoil/planViewModeState";
 
 import PageTemplate from "../../../components/common/PageTemplate";
-import TripInfo from "../../../components/tripDetail/TripInfo";
-import TripPlanListPlaceHolder from "../../../components/tripDetail/TripPlanListPlaceHolder";
 import TripPlanList from "../../../components/tripDetail/TripPlanList";
 import PlanMap from "../../../components/tripDetail/PlanMap";
 import EditModeBottomControlBox from "../../../components/tripDetail/EditModeBottomControlBox";
-
-import { tripPlanState } from "../../../recoil/tripState";
-import { planViewModeState } from "../../../recoil/planViewModeState";
-import { useLoaderData, useParams } from "react-router-dom";
 import Typography from "../../../components/common/Typography";
-import { get } from "../../../utils/api";
+import CalendarIcon from "../../../assets/icons/calendar.svg?react";
 
 interface PlaceData {
   detailRouteId: number;
@@ -45,45 +45,114 @@ interface TripData {
 }
 
 function MyTripDetailPage() {
-  // @todo: id를 통해 일정 데이터 비동기 요청 불러와 State로 관리하기
   const { id } = useParams(); // 파라미터에 게시글 ID
   const nickname = useLoaderData() as string;
+
   const [viewMode, setViewMode] = useRecoilState(planViewModeState);
   const tripPlan = useRecoilValue(tripPlanState);
-  const [data, setData] = useState<TripData | null>(null);
+
+  const [data, setData] = useState<TripData>({
+    id: -1,
+    title: "",
+    departure_date: "",
+    arrival_date: "",
+    days: -1,
+    location: [],
+    plan: [],
+  });
+  const [duration, setDuration] = useState<{
+    departure: DateObject;
+    arrival: DateObject;
+  }>({
+    departure: {
+      year: -1,
+      month: -1,
+      day: -1,
+      dayOfWeek: "월",
+      dateString: "",
+    },
+    arrival: {
+      year: -1,
+      month: -1,
+      day: -1,
+      dayOfWeek: "월",
+      dateString: "",
+    },
+  });
 
   const getData = async (id: number) => {
     const { data } = await get<TripData>(`/my-travel/${id}`);
     console.dir(data);
     setData(data);
+    setDuration({
+      departure: parseDateString(data.departure_date) as DateObject,
+      arrival: parseDateString(data.arrival_date) as DateObject,
+    });
+  };
+
+  const getDurationString = (departure: DateObject, arrival: DateObject) => {
+    let dateString = "";
+    let durationString = "";
+
+    const getDateDiff = () => {
+      const date1 = new Date(departure.dateString);
+      const date2 = new Date(arrival.dateString);
+
+      const diffDate = date1.getTime() - date2.getTime();
+
+      return Math.abs(diffDate / (1000 * 60 * 60 * 24)); // 밀리세컨 * 초 * 분 * 시 = 일
+    };
+
+    const diffDate = getDateDiff();
+    durationString =
+      diffDate === 0 ? "당일치기" : `${diffDate}박 ${diffDate + 1}일`;
+
+    if (departure.dateString === arrival.dateString) {
+      // 1. 출발-도착 날짜가 동일할 경우 YYYY. MM. DD / 당일치기
+      dateString = `${departure.year}. ${departure.month}. ${departure.day}`;
+    } else if (departure.year !== arrival.year) {
+      // 2. 출발-도착 연도가 동일하지 않을 경우 YYYY. MM. DD ~ YYYY. MM. DD
+      dateString = `${departure.year}. ${departure.month}. ${departure.day} ~ ${arrival.year}. ${arrival.month}. ${arrival.day} `;
+    } else {
+      // 3. 출발-도착 연도가 동일할 경우 YYYY. MM. DD ~ MM. DD
+      dateString = `${departure.year}. ${departure.month}. ${departure.day} ~ ${arrival.month}. ${arrival.day} `;
+    }
+
+    return `${dateString} / ${durationString}`;
   };
 
   useEffect(() => {
     getData(Number(id));
     setViewMode("NOPLAN");
-  }, [tripPlan]);
+  }, []);
 
   return (
     <PageTemplate
       nav={viewMode === "EDIT" ? <EditModeBottomControlBox /> : "default"}
+      header={
+        <S.Header>
+          <Typography.Headline size="md">{data.title}</Typography.Headline>
+          <S.DateParagraph>
+            <CalendarIcon />
+            <Typography.Title size="md" color="#a6a6a6">
+              {getDurationString(duration.departure, duration.arrival)}
+            </Typography.Title>
+          </S.DateParagraph>
+        </S.Header>
+      }
     >
-      <TripInfo />
-      {viewMode === "NOPLAN" ? (
-        <>
-          <S.MessageBox>
-            <Typography.Body size="md" color="#5276FA">
-              <p>{nickname}님, 새로운 여행 일정이 만들어졌어요!</p>
-              <p>아래 장소 추가 버튼을 통해 계획을 세워가보세요. 🙂</p>
-            </Typography.Body>
-          </S.MessageBox>
-          <TripPlanListPlaceHolder days={4} />
-        </>
+      {false ? (
+        // {data.plan.length > 0 ? (
+        <PlanMap />
       ) : (
-        <>
-          <PlanMap />
-          <TripPlanList />
-        </>
+        <S.MessageBox>
+          <Typography.Body size="md" color="#5276FA">
+            <p>{nickname}님, 새로운 여행 일정이 만들어졌어요!</p>
+            <p>아래 장소 추가 버튼을 통해 계획을 세워가보세요. 🙂</p>
+          </Typography.Body>
+        </S.MessageBox>
       )}
+      <TripPlanList />
     </PageTemplate>
   );
 }

--- a/src/pages/mytrip/DetailPage/style.ts
+++ b/src/pages/mytrip/DetailPage/style.ts
@@ -1,5 +1,18 @@
 import styled from "styled-components";
 
+export const Header = styled.header`
+  padding: 15px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+export const DateParagraph = styled.p`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+`;
+
 export const MessageBox = styled.div`
   margin-bottom: 20px;
   padding: 16px 20px;

--- a/src/pages/mytrip/MemoPage/index.tsx
+++ b/src/pages/mytrip/MemoPage/index.tsx
@@ -1,0 +1,77 @@
+import * as S from "./style";
+import PageTemplate from "../../../components/common/PageTemplate";
+import Button from "../../../components/common/Button";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { patch } from "../../../utils/api";
+import { useState } from "react";
+import PageHeader from "../../../components/common/PageHeader";
+import Typography from "../../../components/common/Typography";
+
+function MemoPage() {
+  const navigate = useNavigate();
+  const [query] = useSearchParams();
+  const [text, setText] = useState<string>(query.get("text") || "");
+  const detailRouteId = Number(query.get("detailRouteId"));
+
+  const saveMemo = (detailRouteId: number, text: string) => {
+    try {
+      patch(`/my-travel/detail-route/memo`, {
+        id: detailRouteId,
+        memo: text,
+      }).then(() => {
+        navigate(-1);
+      });
+    } catch (error) {
+      alert("메모 저장에 실패했습니다.");
+    }
+  };
+
+  return (
+    <PageTemplate
+      nav={
+        <S.ButtonWrapper>
+          <Button
+            type="normal"
+            width="100%"
+            active={true}
+            size="lg"
+            onClick={() => {
+              saveMemo(detailRouteId, text);
+            }}
+          >
+            저장
+          </Button>
+        </S.ButtonWrapper>
+      }
+      header={
+        <PageHeader>
+          <S.PlaceInfoContainer>
+            <Typography.Headline size="sm">
+              {query.get("placeName") || "장소명"}
+            </Typography.Headline>
+            <S.PlaceInfoBottomBox>
+              <Typography.Title size="md">
+                Day {query.get("day") || "-1"}
+              </Typography.Title>
+              <Typography.Title size="md" color="#A6A6A6">
+                {query.get("date") || "MM.DD(DoW)"}
+              </Typography.Title>
+            </S.PlaceInfoBottomBox>
+          </S.PlaceInfoContainer>
+        </PageHeader>
+      }
+    >
+      <S.MemoTextArea
+        placeholder="메모를 입력해 주세요."
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+        }}
+        maxLength={200}
+      ></S.MemoTextArea>
+      <S.TextCountParagraph>{text.length}/200</S.TextCountParagraph>
+    </PageTemplate>
+  );
+}
+
+export default MemoPage;

--- a/src/pages/mytrip/MemoPage/style.ts
+++ b/src/pages/mytrip/MemoPage/style.ts
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const ButtonWrapper = styled.div`
+  padding: 30px;
+`;
+
+export const PlaceInfoContainer = styled.div`
+  width: calc(100% - 24px);
+  padding-left: 15px;
+  margin-left: 24px;
+`;
+
+export const PlaceInfoBottomBox = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export const MemoTextArea = styled.textarea`
+  padding: 15px;
+  min-height: 260px;
+  width: 100%;
+  border-radius: 10px;
+  border: 0;
+  background-color: ${({ theme }) => theme.gray05};
+`;
+export const TextCountParagraph = styled.p`
+  margin-top: 5px;
+  text-align: right;
+  color: ${({ theme }) => theme.gray02};
+
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 24px;
+  letter-spacing: 0.5px;
+`;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,7 +2,6 @@ import { createBrowserRouter } from "react-router-dom";
 
 import { TUserProfile } from "./assets/types/TUserProfile";
 import MyTripPage from "./pages/mytrip/MyTripPage";
-import TestPage from "./pages/TestPage";
 import PlacePage from "./pages/PlacePage";
 import TermsPage from "./pages/TermsPage";
 
@@ -12,21 +11,17 @@ import MyTripDatesSelectPage from "./pages/mytrip/DatesSelectPage";
 import MyTripLocationSearchPage from "./pages/mytrip/LocationSearchPage";
 import MyTripPlaceCreatePage from "./pages/mytrip/PlaceCreatePage";
 import ViewAllPage from "./pages/mytrip/ViewAllPage";
-
 import ScrapBookPage from "./pages/scrapbook/ScrapBookPage";
 import ScrapBookGroupPage from "./pages/scrapbook/ScrapBookGroupPage";
-
 import ProfilePage from "./pages/profile/ProfilePage";
 import UserEditPage from "./pages/profile/UserEditPage";
 import UserFollowPage from "./pages/profile/UserFollowPage";
-
 import HomePage from "./pages/home/HomePage";
 import SettingsPage from "./pages/profile/SettingsPage";
-
 import ShortFormPage from "./pages/journal/ShortformPage";
-import SnapshotPage from "./pages/journal/SnapshotPage";
-import PostPage from "./pages/journal/PostPage";
-import VideoPage from "./pages/journal/VideoPage";
+// import SnapshotPage from "./pages/journal/SnapshotPage";
+// import PostPage from "./pages/journal/PostPage";
+// import VideoPage from "./pages/journal/VideoPage";
 import LoginPage from "./pages/auth/LoginPage";
 import SignUpPage from "./pages/auth/SignUpPage";
 import ArticlePage from "./pages/ArticlePage";
@@ -45,6 +40,7 @@ import ArticleTestPage from "./pages/ArticleTestPage";
 import { get } from "./utils/api";
 import InquiryDetailPage from "./pages/cscenter/InquiryDetailPage";
 import IsLoginTemplate from "./components/common/isLoginTemplate";
+import MemoPage from "./pages/mytrip/MemoPage";
 
 const router = createBrowserRouter([
   {
@@ -120,6 +116,14 @@ const router = createBrowserRouter([
       const { data } = await get<TUserProfile>(`/user/profile`);
       return data.nickname;
     },
+  },
+  {
+    path: "/mytrip/:id/memo",
+    element: (
+      <IsLoginTemplate>
+        <MemoPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/:id/dateChange",

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -71,52 +71,93 @@ const router = createBrowserRouter([
   /* ---- 내 여행 페이지 ---- */
   {
     path: "/mytrip",
-    element: <IsLoginTemplate>
-      <MyTripPage />
-    </IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/all",
-    element: <IsLoginTemplate><ViewAllPage /></IsLoginTemplate>
+    element: (
+      <IsLoginTemplate>
+        <ViewAllPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/create",
-    element: <IsLoginTemplate><MyTripDatesSelectPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripDatesSelectPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/create/location",
-    element: <IsLoginTemplate><MyTripLocationSelectPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripLocationSelectPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/place/:id",
-    element: <IsLoginTemplate><PlaceAddPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <PlaceAddPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/:id",
-    element: <IsLoginTemplate><MyTripDetailPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripDetailPage />
+      </IsLoginTemplate>
+    ),
+    loader: async () => {
+      const { data } = await get<TUserProfile>(`/user/profile`);
+      return data.nickname;
+    },
   },
   {
     path: "/mytrip/:id/dateChange",
-    element: <IsLoginTemplate><MyTripDatesSelectPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripDatesSelectPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/:id/:day/search",
-    element: <IsLoginTemplate><MyTripLocationSearchPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripLocationSearchPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/mytrip/:id/create",
-    element: <IsLoginTemplate><MyTripPlaceCreatePage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <MyTripPlaceCreatePage />
+      </IsLoginTemplate>
+    ),
   },
   /* ---- 유저 프로필 페이지 ---- */
   {
     path: "/profile",
-    element: (<IsLoginTemplate><ProfilePage /></IsLoginTemplate>),
+    element: (
+      <IsLoginTemplate>
+        <ProfilePage />
+      </IsLoginTemplate>
+    ),
     loader: async () => {
-      if(localStorage.getItem("access_token")){
-        const { data } = await get<TUserProfile>(`/user/profile`)
+      if (localStorage.getItem("access_token")) {
+        const { data } = await get<TUserProfile>(`/user/profile`);
         return data;
-      }
-      else {
+      } else {
         return {
           id: -1,
           nickname: "string",
@@ -132,33 +173,53 @@ const router = createBrowserRouter([
   },
   {
     path: "/profile/:uid/follow",
-    element: <IsLoginTemplate><UserFollowPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <UserFollowPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // TODO : [LOGIN 기능 정의 이후] LOGIN 정보를 기반으로 접근 허용 / 거부
     path: "/profile/edit",
-    element: <IsLoginTemplate><UserEditPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <UserEditPage />
+      </IsLoginTemplate>
+    ),
     loader: async () => {
-      const { data } = await get<TUserProfile>(`/user/profile`)
+      const { data } = await get<TUserProfile>(`/user/profile`);
       return data;
     },
   },
   {
     path: "/profile/settings",
-    element: <IsLoginTemplate><SettingsPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <SettingsPage />
+      </IsLoginTemplate>
+    ),
     loader: async () => {
-      const { data } = await get<TUserProfile>(`/user/profile`)
+      const { data } = await get<TUserProfile>(`/user/profile`);
       return data;
     },
   },
   /* ---- 스크랩 페이지 ---- */
   {
     path: "/scrapbook",
-    element: <IsLoginTemplate><ScrapBookPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <ScrapBookPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     path: "/scrapbook/:id",
-    element: <IsLoginTemplate><ScrapBookGroupPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <ScrapBookGroupPage />
+      </IsLoginTemplate>
+    ),
   },
   /* ---- 로그인 페이지 ---- */
   {
@@ -173,65 +234,102 @@ const router = createBrowserRouter([
   {
     // 고객센터/도움말
     path: "/cscenter",
-    element: <IsLoginTemplate><CSCenterPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <CSCenterPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // FAQ 페이지
     path: "/cscenter/faq",
-    element: <IsLoginTemplate><FAQPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <FAQPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // FAQ 상세 페이지
     path: "/cscenter/faq/:id",
-    element: <IsLoginTemplate><FAQDetailPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <FAQDetailPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 문의 하기
     path: "/cscenter/inquiry",
     element: <InquiryPage />,
     loader: async () => {
-      const { data } = await get<TUserProfile>(`/user/profile`)
+      const { data } = await get<TUserProfile>(`/user/profile`);
+      console.dir(data);
       return data.nickname;
     },
   },
   {
     // 내 문의 detail page
     path: "/cscenter/inquiry/:id",
-    element: <IsLoginTemplate><InquiryDetailPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <InquiryDetailPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 내 문의 내역
     path: "/cscenter/history",
-    element: <IsLoginTemplate><InquiryHistoryPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <InquiryHistoryPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 공지사항
     path: "/cscenter/announce",
-    element: <IsLoginTemplate><AnnouncePage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <AnnouncePage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 공지사항 상세보기
     path: "/cscenter/announce/:id",
-    element: <IsLoginTemplate><AnnounceDetailPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <AnnounceDetailPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 의견 보내기
     path: "/cscenter/feedback",
-    element: <IsLoginTemplate><FeedBackPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <FeedBackPage />
+      </IsLoginTemplate>
+    ),
   },
   {
     // 장소 페이지
     path: "/place/:id",
-    element: <IsLoginTemplate><PlacePage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <PlacePage />
+      </IsLoginTemplate>
+    ),
   },
-  // 아티클 
+  // 아티클
   {
-    path:"/article/test",
-    element:<ArticleTestPage />
+    path: "/article/test",
+    element: <ArticleTestPage />,
   },
   {
-    path:"/article/:id",
-    element:<ArticlePage />
+    path: "/article/:id",
+    element: <ArticlePage />,
   },
   {
     // 약관
@@ -241,16 +339,24 @@ const router = createBrowserRouter([
   {
     // 탈퇴하기
     path: "/leave",
-    element: <IsLoginTemplate><ResignPage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <ResignPage />
+      </IsLoginTemplate>
+    ),
     loader: async () => {
-      const { data } = await get<TUserProfile>(`/user/profile`)
+      const { data } = await get<TUserProfile>(`/user/profile`);
       return data;
     },
   },
   {
     // 탈퇴 완료
     path: "/leave/done",
-    element: <IsLoginTemplate><ResignDonePage /></IsLoginTemplate>,
+    element: (
+      <IsLoginTemplate>
+        <ResignDonePage />
+      </IsLoginTemplate>
+    ),
   },
 ]);
 

--- a/src/utils/parseDateString.ts
+++ b/src/utils/parseDateString.ts
@@ -5,6 +5,7 @@ export interface DateObject {
   month: number;
   day: number;
   dayOfWeek: DayOfWeek;
+  dateString: string;
 }
 
 export function parseDateString(dateString: string): DateObject | null {
@@ -23,6 +24,7 @@ export function parseDateString(dateString: string): DateObject | null {
       month: Number(month),
       day: Number(day),
       dayOfWeek,
+      dateString: dateString,
     };
   } else {
     console.error("날짜 형식이 yyyy-mm-dd와 일치하지 않아 변환할 수 없습니다.");


### PR DESCRIPTION
### 작업한 내용
관련 이슈: #110 

![image](https://github.com/F-orever/gabozago_FE/assets/102221305/4d8a25e7-7f1f-47e7-9d85-c69233aca3f6)

- [x] API로 데이터 불러오기
- [x] 헤더 디자인 변경
- [x] 일정 날짜표기법, 디자인 변경
- [x] 메모하기 버튼 추가 및 기능구현
- [x] 장소 카드에 메모 및 지역, 테마 추가
- [x] 일자별 인덱스 마커 색상 주기
- [x] 일정보기에서 장소 추가 버튼 클릭 시 navigate 

### 추후 작업할 내용
- 일정 순서 편집, 삭제
- 구글 맵에 마커 표시 및 클릭 시 윈도우 띄우기
- 장소 간 거리 표시
난이도 극상 모음zip