### PR TITLE
Fix/#149 로그인/회원가입 페이지 및 장소페이지 QA 반영

### DIFF
--- a/src/components/signUp/CheckBoxs/index.tsx
+++ b/src/components/signUp/CheckBoxs/index.tsx
@@ -38,6 +38,7 @@ function CheckBoxs({setCheckboxActive}: Props) {
   const [ageCheck, setAgeCheck] = useState(false);
   const [serviceCheck, setServiceCheck] = useState(false);
   const [personalCheck, setPersonalCheck] = useState(false);
+  const [eventCheck, setEventCheck] = useState(false);
 
   useEffect(() => {
     if(allChecks === true) {
@@ -55,6 +56,12 @@ function CheckBoxs({setCheckboxActive}: Props) {
       setCheckboxActive(false);
     }
   }, [ageCheck, serviceCheck, personalCheck])
+
+  useEffect(() => {
+    if(eventCheck && ageCheck && serviceCheck && personalCheck) {
+      setAllChecks(true);
+    }
+  }, [eventCheck, ageCheck, serviceCheck, personalCheck])
 
   return (
     <S.CheckBoxsContainer>
@@ -99,6 +106,9 @@ function CheckBoxs({setCheckboxActive}: Props) {
                   break;
                 case "personalCheck" :
                   setPersonalCheck(e.currentTarget.checked);
+                  break;
+                case "eventCheck" :
+                  setEventCheck(e.currentTarget.checked);
                   break;
               }
               if (!e.currentTarget.checked) {

--- a/src/components/signUp/CheckBoxs/index.tsx
+++ b/src/components/signUp/CheckBoxs/index.tsx
@@ -119,7 +119,9 @@ function CheckBoxs({setCheckboxActive}: Props) {
             <S.CheckBoxLabel htmlFor={`${term.id}`}>
               {
                 term.link ?
-                <S.TermLink to={term.link}>{term.label}</S.TermLink>
+                <S.TermLink onClick={() => {
+                  window.open(term.link, "_blank", 'width=500,height=600');
+                }}>{term.label}</S.TermLink>
                 :
                 term.label
               }

--- a/src/components/signUp/CheckBoxs/style.ts
+++ b/src/components/signUp/CheckBoxs/style.ts
@@ -45,8 +45,9 @@ export const CheckBoxLabel = styled.label`
     line-height: 22px;
 `
 
-export const TermLink = styled(Link)`
+export const TermLink = styled.span`
     color:${({theme}) => theme.black};
+    text-decoration-line: underline;
 `
 
 export const CheckBoxLabelLink = styled(Link)`

--- a/src/components/signUp/Nickname/index.tsx
+++ b/src/components/signUp/Nickname/index.tsx
@@ -18,7 +18,7 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
     const [nicknameAlert, setNicknameAlert] = useState("");
 
     useEffect(() => {
-      if(nickname === "") return;
+      if(nickname === "" || nickname === null) return;
 
       const access = localStorage.getItem('access_token');
       const refresh = localStorage.getItem('refresh_token');

--- a/src/components/signUp/Nickname/index.tsx
+++ b/src/components/signUp/Nickname/index.tsx
@@ -38,9 +38,12 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
             setNicknameAlert(`사용 가능한 닉네임이에요!`);
             setIsNicknameOk(true);
           } else {
-            setNicknameAlert(`${res.data.message}`);
+            setNicknameAlert(`사용 불가능한 닉네임이에요!`);
             setIsNicknameOk(false);
           }
+        }).catch((err) => {
+          setNicknameAlert(`${err.response.data.message}`);
+          setIsNicknameOk(false);
         });
       
       localStorage.setItem('access_token', access as string);
@@ -83,7 +86,7 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
             
             localStorage.removeItem('access_token');
             localStorage.removeItem('refresh_token');
-
+            
             if(!isNicknameValid(nickname as string)) {
               setNicknameAlert(`한글, 영어, 숫자, _, .만 가능합니다.`);
               setIsNicknameOk(false);
@@ -97,7 +100,7 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
                   setIsNicknameOk(true);
                 } 
               }).catch((err) => {
-                setNicknameAlert(`${err.response.data.message}`);
+                setNicknameAlert(`${err.response.data.message === "IMPOSSIBLE" ? "사용 불가능한 닉네임이에요!" : err.response.data.message}`);
                 setIsNicknameOk(false);
               }).finally(() => {
                 localStorage.setItem('access_token', access as string);

--- a/src/components/signUp/Nickname/index.tsx
+++ b/src/components/signUp/Nickname/index.tsx
@@ -18,21 +18,27 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
     const [nicknameAlert, setNicknameAlert] = useState("");
 
     useEffect(() => {
+      if(nickname === "") return;
+
       const access = localStorage.getItem('access_token');
       const refresh = localStorage.getItem('refresh_token');
-
-      console.log(access);
       
       localStorage.removeItem('access_token');
       localStorage.removeItem('refresh_token');
 
-      get<{message: "POSSIBLE" | "IMPOSSIBLE"}>(`/user/nickname/${nickname}`)
+      if(!isNicknameValid(nickname as string)) {
+        setNicknameAlert(`한글, 영어, 숫자, _, .만 가능합니다.`);
+        setIsNicknameOk(false);
+        return;
+      }
+
+      get<{message: string}>(`/user/nickname/${nickname}`)
         .then((res) => {
           if(res.data.message === "POSSIBLE") {
             setNicknameAlert(`사용 가능한 닉네임이에요!`);
             setIsNicknameOk(true);
           } else {
-            setNicknameAlert(`사용 불가능한 닉네임이에요!`);
+            setNicknameAlert(`${res.data.message}`);
             setIsNicknameOk(false);
           }
         });
@@ -40,6 +46,13 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
       localStorage.setItem('access_token', access as string);
       localStorage.setItem('refresh_token', refresh as string);
     }, [])
+
+    function isNicknameValid(nickname: string) {
+      if(nickname.includes(`?`)) {
+        return false;
+      }
+      return true
+    }
 
     return(
       <>
@@ -54,7 +67,6 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
           placeholder="닉네임을 입력하세요. (중복 불가)"
           minLength={2}
           maxLength={15}
-          pattern="^(?=.*[a-z0-9가-힣])[a-z0-9가-힣_.]{2,16}$"
           alert={
             <S.AlertMessage color={nicknameAlert.length > 14 ? "red" : "blue"}>
               {nicknameAlert}
@@ -72,14 +84,20 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
             localStorage.removeItem('access_token');
             localStorage.removeItem('refresh_token');
 
-            get<{message: "POSSIBLE" | "IMPOSSIBLE"}>(`/user/nickname/${nickname}`)
+            if(!isNicknameValid(nickname as string)) {
+              setNicknameAlert(`한글, 영어, 숫자, _, .만 가능합니다.`);
+              setIsNicknameOk(false);
+              return;
+            }
+
+            get<{message: string}>(`/user/nickname/${nickname}`)
               .then((res) => {
                 if(res.data.message === "POSSIBLE") {
                   setNicknameAlert(`사용 가능한 닉네임이에요!`);
                   setIsNicknameOk(true);
                 } 
               }).catch((err) => {
-                setNicknameAlert(`사용 불가능한 닉네임이에요!`);
+                setNicknameAlert(`${err.response.data.message}`);
                 setIsNicknameOk(false);
               }).finally(() => {
                 localStorage.setItem('access_token', access as string);

--- a/src/components/signUp/Nickname/index.tsx
+++ b/src/components/signUp/Nickname/index.tsx
@@ -44,10 +44,11 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
         }).catch((err) => {
           setNicknameAlert(`${err.response.data.message}`);
           setIsNicknameOk(false);
+        }).finally(() => {
+          localStorage.setItem('access_token', access as string);
+          localStorage.setItem('refresh_token', refresh as string);
         });
       
-      localStorage.setItem('access_token', access as string);
-      localStorage.setItem('refresh_token', refresh as string);
     }, [])
 
     function isNicknameValid(nickname: string) {
@@ -86,7 +87,7 @@ function Nickname({setIsNicknameOk, defaultValue}: Props) {
             
             localStorage.removeItem('access_token');
             localStorage.removeItem('refresh_token');
-            
+
             if(!isNicknameValid(nickname as string)) {
               setNicknameAlert(`한글, 영어, 숫자, _, .만 가능합니다.`);
               setIsNicknameOk(false);

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -92,7 +92,7 @@ function PlacePage() {
                             {data.image.map((img) => <img src={img} />)}
                         </S.ImgSlider>
                     }
-                    {imageURL && <img src={imageURL} />}
+                    {imageURL && <S.TmpImg src={imageURL} />}
                     <S.ContentList>
                         <S.InfomationList>
                             <S.InfomationItem>
@@ -134,9 +134,9 @@ function PlacePage() {
                                     placeId: id
                                 }).then((response) => {
                                     if(response.data.message === "Create Success") {
-                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white">가 스크랩 되었습니다.</Typography.Body></S.AlertMessageContainer>);
+                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >가 스크랩 되었습니다.</Typography.Body></S.AlertMessageContainer>);
                                     } else {
-                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white">가 스크랩 삭제했습니다.</Typography.Body></S.AlertMessageContainer>);
+                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >가 스크랩 삭제했습니다.</Typography.Body></S.AlertMessageContainer>);
                                     }
 
                                     alertOpen();

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -136,7 +136,7 @@ function PlacePage() {
                                     if(response.data.message === "Create Success") {
                                         setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >(이)가 스크랩 되었습니다.</Typography.Body></S.AlertMessageContainer>);
                                     } else {
-                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >(이)가 스크랩 삭제했습니다.</Typography.Body></S.AlertMessageContainer>);
+                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >(이)가 스크랩 목록에서 삭제되었습니다.</Typography.Body></S.AlertMessageContainer>);
                                     }
 
                                     alertOpen();

--- a/src/pages/PlacePage/index.tsx
+++ b/src/pages/PlacePage/index.tsx
@@ -134,9 +134,9 @@ function PlacePage() {
                                     placeId: id
                                 }).then((response) => {
                                     if(response.data.message === "Create Success") {
-                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >가 스크랩 되었습니다.</Typography.Body></S.AlertMessageContainer>);
+                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >(이)가 스크랩 되었습니다.</Typography.Body></S.AlertMessageContainer>);
                                     } else {
-                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >가 스크랩 삭제했습니다.</Typography.Body></S.AlertMessageContainer>);
+                                        setAlertMessage( <S.AlertMessageContainer><S.AlertMessageName>{data.name}</S.AlertMessageName><Typography.Body size="lg" color="white" maxWidth={140} >(이)가 스크랩 삭제했습니다.</Typography.Body></S.AlertMessageContainer>);
                                     }
 
                                     alertOpen();

--- a/src/pages/PlacePage/style.ts
+++ b/src/pages/PlacePage/style.ts
@@ -39,6 +39,7 @@ export const ContentContainer = styled.div`
 
 export const ImgSlider = styled.div`
   width: 100%;
+  max-height:200px;
   overflow: auto;
   position: relative;
 
@@ -49,8 +50,9 @@ export const ImgSlider = styled.div`
 
   img {
     width: 100%;
+    max-height:200px;
     scroll-snap-align: start;
-    object-fit: contain;
+    object-fit: cover;
     flex-shrink: 0;
   }
 
@@ -59,6 +61,13 @@ export const ImgSlider = styled.div`
     scrollbar-width: none;
   }
 `;
+
+export const TmpImg = styled.img`
+    width: 100%;
+    max-height:200px;
+    object-fit: cover;
+    flex-shrink: 0;
+`
 
 export const ImgRegistContainer = styled.div`
   width: 100%;
@@ -172,6 +181,10 @@ export const AlertMessageContainer = styled.div`
   display:flex;
   justify-content:center;
   align-items:center;
+
+  span:last-child{
+    flex-shrink: 0;
+  }
 `
 
 export const AlertMessageName = styled.span`
@@ -183,7 +196,6 @@ export const AlertMessageName = styled.span`
 
   word-break: keep-all;
   overflow-wrap: anywhere;
-  max-width: 160px;
   text-overflow: ellipsis;
   overflow: hidden;
   display: -webkit-box;


### PR DESCRIPTION
### 작업한 내용
관련 이슈: #149 
- 장소 페이지 UI ( 영업종료 옆 불필요한 . / 스크랩 팝업 UI / 최초 이미지 깨짐 )
- 회원가입 페이지 UI ( 모두 체크시 다시 체크 표시 )
- 닉네임 validation 로직 수정
- 회원가입 페이지 에서 약관페이지 갔다오면 value 유지 -> 약관 페이지를 새 창에 띄우는 형태

### 추후 해결해야 할 문제
- 영업시간 Handling 이 단순한 문제가 아니라서 일단 후순위로 연기 및 상황에 따라 Backend 에서 처리
- 약관 페이지 새창에 띄우는 형태 모바일에서 테스트 필요
